### PR TITLE
Metric event: check if class or instance is referenced

### DIFF
--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -235,6 +235,11 @@ namespace event
             return values_[i];
         }
 
+        bool has_metric_class() const
+        {
+            return static_cast<bool>(metric_class_);
+        }
+
         otf2::definition::metric_class metric_class() const
         {
             return metric_class_;
@@ -244,6 +249,11 @@ namespace event
         {
             metric_instance_ = nullptr;
             metric_class_ = mc;
+        }
+
+        bool has_metric_instance() const
+        {
+            return static_cast<bool>(metric_instance_);
         }
 
         otf2::definition::metric_instance metric_instance() const


### PR DESCRIPTION
Metric events may reference either a metric class or metric instance.
Add the `has_metric_{class,instance}` member methods to check for the
presence of either on an existing metric event.