### PR TITLE
Reduce copy overhead when writing metric events

### DIFF
--- a/include/otf2xx/definition/container.hpp
+++ b/include/otf2xx/definition/container.hpp
@@ -171,6 +171,11 @@ namespace definition
             return data.size();
         }
 
+        iterator find(key_type key) const
+        {
+            return iterator(data.find(key), data.end());
+        }
+
     public:
         iterator begin() const
         {
@@ -270,7 +275,7 @@ namespace definition
         static_assert(otf2::traits::is_definition<Definition>::value,
                       "The type Definition has to be an otf2::definition");
     };
-}
-} // namespace otf2::definition
+} // namespace definition
+} // namespace otf2
 
 #endif // INCLUDE_OTF2XX_DEFINITIONS_CONTAINER_HPP

--- a/include/otf2xx/event/detail/metric_values.hpp
+++ b/include/otf2xx/event/detail/metric_values.hpp
@@ -1,0 +1,199 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2018, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_EVENT_DETAIL_METRIC_VALUES_HPP
+#define INCLUDE_OTF2XX_EVENT_DETAIL_METRIC_VALUES_HPP
+
+#include <otf2xx/event/detail/value_proxy.hpp>
+
+#include <otf2xx/definition/metric_class.hpp>
+
+#include <vector>
+
+namespace otf2
+{
+namespace event
+{
+    namespace detail
+    {
+        class metric_values
+        {
+        public:
+            metric_values(std::vector<OTF2_Type>&& type_ids,
+                          std::vector<OTF2_MetricValue>&& metric_values)
+            : type_ids_(std::move(type_ids)), values_(std::move(metric_values))
+            {
+                if (type_ids_.size() != values_.size())
+                {
+                    make_exception(
+                        "attempting to construct metric_values from data of different sizes");
+                }
+            }
+
+            metric_values(const otf2::definition::metric_class& metric_class)
+            : type_ids_(metric_class.size()), values_(metric_class.size())
+            {
+                for (std::size_t i = 0; i < metric_class.size(); ++i)
+                {
+                    type_ids_[i] = static_cast<OTF2_Type>(metric_class[i].value_type());
+                }
+            }
+
+            std::size_t size() const
+            {
+                return type_ids_.size();
+            }
+
+            const std::vector<OTF2_Type>& type_ids() const
+            {
+                return type_ids_;
+            }
+
+            const std::vector<OTF2_MetricValue>& values() const
+            {
+                return values_;
+            }
+
+            detail::typed_value_proxy at(std::size_t index)
+            {
+                if (index >= size())
+                {
+                    throw std::out_of_range("Out of bounds access in metric_values");
+                }
+
+                return { type_ids_[index], values_[index] };
+            }
+
+            detail::const_typed_value_proxy at(std::size_t index) const
+            {
+                if (index >= size())
+                {
+                    throw std::out_of_range("Out of bounds access in metric_values");
+                }
+
+                return { type_ids_[index], values_[index] };
+            }
+
+            detail::typed_value_proxy operator[](std::size_t index)
+            {
+                return { type_ids_[index], values_[index] };
+            }
+
+            detail::const_typed_value_proxy operator[](std::size_t index) const
+            {
+                return { type_ids_[index], values_[index] };
+            }
+
+            template <bool IsMutable>
+            class base_iterator
+            {
+            public:
+                using value_type = detail::base_typed_value_proxy<IsMutable>;
+
+                using type_type = typename value_type::type_type;
+                using metric_value_type = typename value_type::metric_value_type;
+
+            private:
+                friend metric_values;
+
+                base_iterator(type_type* type_id, metric_value_type* value)
+                : type_ptr_(type_id), value_ptr_(value)
+                {
+                }
+
+            public:
+                bool operator==(const base_iterator& rhs) const
+                {
+                    return type_ptr_ == rhs.type_ptr_ && value_ptr_ == rhs.value_ptr_;
+                }
+
+                bool operator!=(const base_iterator& rhs) const
+                {
+                    return !(*this == rhs);
+                }
+
+                value_type operator*()
+                {
+                    return { *type_ptr_, *value_ptr_ };
+                }
+
+                base_iterator& operator++()
+                {
+                    ++type_ptr_;
+                    ++value_ptr_;
+                    return *this;
+                }
+
+                base_iterator operator++(int)
+                {
+                    return { type_ptr_++, value_ptr_++ };
+                }
+
+            private:
+                type_type* type_ptr_;
+                metric_value_type* value_ptr_;
+            };
+
+            using iterator = base_iterator<true>;
+            using const_iterator = base_iterator<false>;
+
+            const_iterator begin() const
+            {
+                return const_iterator{ type_ids_.data(), values_.data() };
+            }
+
+            iterator begin()
+            {
+                return iterator{ type_ids_.data(), values_.data() };
+            }
+
+            const_iterator end() const
+            {
+                return const_iterator{ type_ids_.data() + size(), values_.data() + size() };
+            }
+
+            iterator end()
+            {
+                return iterator{ type_ids_.data() + size(), values_.data() + size() };
+            }
+
+        private:
+            std::vector<OTF2_Type> type_ids_;
+            std::vector<OTF2_MetricValue> values_;
+        };
+    } // namespace detail
+} // namespace event
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_EVENT_DETAIL_METRIC_VALUES_HPP

--- a/include/otf2xx/event/detail/value_proxy.hpp
+++ b/include/otf2xx/event/detail/value_proxy.hpp
@@ -1,0 +1,279 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2018, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_EVENT_DETAIL_VALUE_PROXY_HPP
+#define INCLUDE_OTF2XX_EVENT_DETAIL_VALUE_PROXY_HPP
+
+#include <otf2xx/common.hpp>
+#include <otf2xx/definition/detail/weak_ref.hpp>
+#include <otf2xx/definition/metric_member.hpp>
+#include <otf2xx/exception.hpp>
+
+#include <otf2/OTF2_Events.h>
+
+#include <cmath> // for std::pow
+
+namespace otf2
+{
+namespace event
+{
+    namespace detail
+    {
+        /**
+         * \brief A proxy class that allows type safe access to a metric value
+         *
+         * For performance reasons, the types and values of a metric event are
+         * stored in separate locations. This proxy class allows to set and
+         * retrieve a value with the correct type.
+         */
+        template <bool IsMutable>
+        class base_typed_value_proxy
+        {
+        public:
+            using type_type =
+                typename std::conditional<IsMutable, OTF2_Type, const OTF2_Type>::type;
+
+            using metric_value_type = typename std::conditional<IsMutable, OTF2_MetricValue,
+                                                                const OTF2_MetricValue>::type;
+
+        public:
+            base_typed_value_proxy(type_type& type, metric_value_type& value)
+            : type_(type), value_(value)
+            {
+            }
+
+            double as_double() const
+            {
+                switch (type())
+                {
+                case otf2::common::type::Double:
+                    return static_cast<double>(value_.floating_point);
+                case otf2::common::type::int64:
+                    return static_cast<double>(value_.signed_int);
+                case otf2::common::type::uint64:
+                    return static_cast<double>(value_.unsigned_int);
+                default:
+                    make_exception("Unexpected type given in metric member");
+                }
+
+                return 0;
+            }
+
+            std::int64_t as_int64() const
+            {
+                switch (type())
+                {
+                case otf2::common::type::Double:
+                    return static_cast<std::int64_t>(value_.floating_point);
+                case otf2::common::type::int64:
+                    return static_cast<std::int64_t>(value_.signed_int);
+                case otf2::common::type::uint64:
+                    return static_cast<std::int64_t>(value_.unsigned_int);
+                default:
+                    make_exception("Unexpected type given in metric member");
+                }
+
+                return 0;
+            }
+
+            std::uint64_t as_uint64() const
+            {
+                switch (type())
+                {
+                case otf2::common::type::Double:
+                    return static_cast<std::uint64_t>(value_.floating_point);
+                case otf2::common::type::int64:
+                    return static_cast<std::uint64_t>(value_.signed_int);
+                case otf2::common::type::uint64:
+                    return static_cast<std::uint64_t>(value_.unsigned_int);
+                default:
+                    make_exception("Unexpected type given in metric member");
+                }
+
+                return 0;
+            }
+
+            template <typename T, bool Mutable = IsMutable>
+            std::enable_if_t<Mutable && std::is_arithmetic<T>::value> value(T x)
+            {
+                switch (type())
+                {
+                case otf2::common::type::Double:
+                    value_.floating_point = static_cast<double>(x);
+                    break;
+                case otf2::common::type::int64:
+                    value_.signed_int = static_cast<std::int64_t>(x);
+                    break;
+                case otf2::common::type::uint64:
+                    value_.unsigned_int = static_cast<std::uint64_t>(x);
+                    break;
+                default:
+                    make_exception("Unexpected type given in metric member");
+                }
+            }
+
+            template <typename T>
+            base_typed_value_proxy operator=(T x)
+            {
+                value(x);
+                return { *this };
+            }
+
+            otf2::common::type type() const
+            {
+                return static_cast<otf2::common::type>(type_);
+            }
+
+            template <bool Mutable = IsMutable>
+            std::enable_if_t<Mutable> type(otf2::common::type type_id)
+            {
+                type_ = static_cast<OTF2_Type>(type_id);
+            }
+
+            template <bool Mutable = IsMutable>
+            std::enable_if_t<Mutable> type(OTF2_Type type_id)
+            {
+                type_ = type_id;
+            }
+
+        private:
+            type_type& type_;
+            metric_value_type& value_;
+        };
+
+        using typed_value_proxy = base_typed_value_proxy<true>;
+        using const_typed_value_proxy = base_typed_value_proxy<false>;
+
+        /**
+         * \brief A proxy class allowing type safe, correctly scaled access to a
+         *        metric value
+         */
+        template <bool IsMutable>
+        class base_value_proxy
+        {
+            template <typename T>
+            T scale(T x) const
+            {
+                using value_base_type = otf2::definition::metric_member::value_base_type;
+
+                int base;
+                switch (metric_->value_base())
+                {
+                case value_base_type::binary:
+                    base = 2;
+                    break;
+                case value_base_type::decimal:
+                    base = 10;
+                    break;
+                }
+                return x * std::pow(base, metric_->value_exponent());
+            }
+
+        public:
+            using typed_value_proxy = detail::base_typed_value_proxy<IsMutable>;
+
+            // This is OTF2_Type, or const OTF2_Type if IsMutable == true
+            using type_type = typename typed_value_proxy::type_type;
+
+            // ... and the same thing for OTF2_MetricValue
+            using metric_value_type = typename typed_value_proxy::metric_value_type;
+
+            base_value_proxy(
+                type_type& type, metric_value_type& value,
+                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
+            : value_(type, value), metric_(metric)
+            {
+            }
+
+            base_value_proxy(
+                const typed_value_proxy& value,
+                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
+            : value_(value), metric_(metric)
+            {
+            }
+
+            base_value_proxy(
+                typed_value_proxy&& value,
+                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
+            : value_(std::move(value)), metric_(metric)
+            {
+            }
+
+            double as_double() const
+            {
+                return scale<double>(value_.as_double());
+            }
+
+            std::int64_t as_int64() const
+            {
+                return scale<std::int64_t>(value_.as_int64());
+            }
+
+            std::uint64_t as_uint64() const
+            {
+                return scale<std::uint64_t>(value_.as_uint64());
+            }
+
+            template <typename T, bool Mutable = IsMutable>
+            std::enable_if_t<Mutable> set(T x)
+            {
+                value_.value(x);
+            }
+
+            template <typename T, bool Mutable = IsMutable>
+            std::enable_if_t<Mutable, base_value_proxy&> operator=(T x)
+            {
+                value_ = x;
+                return *this;
+            }
+
+            otf2::common::type type() const
+            {
+                assert(value_.type() == metric_->value_type());
+
+                return value_.type();
+            }
+
+        private:
+            typed_value_proxy value_;
+            otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric_;
+        };
+
+        using value_proxy = base_value_proxy<true>;
+        using const_value_proxy = base_value_proxy<false>;
+    } // namespace detail
+} // namespace event
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_EVENT_DETAIL_VALUE_PROXY_HPP

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -389,18 +389,15 @@ namespace event
 
             // Look up the index of a member inside of metric class and use it to
             // construct a value_proxy from the right OTF2_Type and OTF2_MetricValue.
-            std::size_t index = 0;
-            for (const auto& class_member : metric_class)
-            {
-                if (class_member == member)
-                {
-                    return value_proxy{ values_[index], member };
-                }
 
-                index++;
+            auto it = std::find(metric_class.begin(), metric_class.end(), member);
+            if (it == metric_class.end())
+            {
+                throw std::out_of_range("Failed to look up metric_member inside metric_class");
             }
 
-            throw std::out_of_range("Failed to look up metric_member inside metric_class");
+            auto index = std::distance(metric_class.begin(), it);
+            return value_proxy{ values_[index], member };
         }
 
         bool has_metric_class() const

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -385,6 +385,8 @@ namespace event
             // if the event was constructed without a reference to a metric
             // class or metric instance.
 
+            assert(metric_class.is_valid());
+
             // Look up the index of a member inside of metric class and use it to
             // construct a value_proxy from the right OTF2_Type and OTF2_MetricValue.
             std::size_t index = 0;

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -286,6 +286,15 @@ namespace event
                 }
             }
 
+            metric_values(const otf2::definition::metric_class& metric_class)
+            : type_ids_(metric_class.size()), values_(metric_class.size())
+            {
+                for (std::size_t i = 0; i < metric_class.size(); ++i)
+                {
+                    type_ids_[i] = static_cast<OTF2_Type>(metric_class[i].value_type());
+                }
+            }
+
             std::size_t size() const
             {
                 return type_ids_.size();
@@ -350,6 +359,19 @@ namespace event
                const otf2::definition::metric_instance& metric_c, metric_values&& values)
         : base<metric>(al, timestamp), metric_class_(), metric_instance_(metric_c),
           values_(std::move(values))
+        {
+        }
+
+        // construct without values, but reserve memory for them
+        metric(otf2::chrono::time_point timestamp, const otf2::definition::metric_class& metric_c)
+        : base<metric>(timestamp), metric_class_(metric_c), metric_instance_(), values_(metric_c)
+        {
+        }
+
+        metric(OTF2_AttributeList* al, otf2::chrono::time_point timestamp,
+               const otf2::definition::metric_class& metric_c)
+        : base<metric>(al, timestamp), metric_class_(metric_c), metric_instance_(),
+          values_(metric_c)
         {
         }
 

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -507,7 +507,7 @@ namespace event
         {
             auto metric_class = resolve_metric_class_ref();
 
-            assert(metric_class->is_valid());
+            assert(static_cast<bool>(metric_class));
 
             return value_proxy(values_[index], (*metric_class)[index]);
         }
@@ -516,7 +516,7 @@ namespace event
         {
             auto metric_class = resolve_metric_class_ref();
 
-            assert(metric_class->is_valid());
+            assert(static_cast<bool>(metric_class));
 
             return const_value_proxy(values_[index], (*metric_class)[index]);
         }
@@ -529,7 +529,7 @@ namespace event
             // if the event was constructed without a reference to a metric
             // class or metric instance.
 
-            assert(metric_class->is_valid());
+            assert(static_cast<bool>(metric_class));
 
             // Look up the index of a member inside of metric class and use it to
             // construct a value_proxy from the right OTF2_Type and OTF2_MetricValue.

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -378,7 +378,7 @@ namespace event
         // copy constructor with new timestamp
         metric(const otf2::event::metric& other, otf2::chrono::time_point timestamp)
         : base<metric>(other, timestamp), metric_class_(other.metric_class()),
-          metric_instance_(other.metric_instance()), values_(other.values())
+          metric_instance_(other.metric_instance()), values_(other.raw_values())
         {
         }
 
@@ -389,12 +389,12 @@ namespace event
         {
         }
 
-        metric_values& values()
+        metric_values& raw_values()
         {
             return values_;
         }
 
-        const metric_values& values() const
+        const metric_values& raw_values() const
         {
             return values_;
         }

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -2,7 +2,7 @@
  * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
  * otf2xx - A wrapper for the Open Trace Format 2 library
  *
- * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * Copyright (c) 2013-2018, Technische Universität Dresden, Germany
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,9 @@
 #ifndef INCLUDE_OTF2XX_EVENT_METRIC_HPP
 #define INCLUDE_OTF2XX_EVENT_METRIC_HPP
 
+#include <otf2xx/event/detail/metric_values.hpp>
+#include <otf2xx/event/detail/value_proxy.hpp>
+
 #include <otf2xx/definition/fwd.hpp>
 #include <otf2xx/definition/metric_member.hpp>
 
@@ -42,410 +45,34 @@
 
 #include <otf2xx/chrono/chrono.hpp>
 
-#include <otf2/OTF2_Events.h>
-
 #include <otf2xx/exception.hpp>
 
 #include <otf2xx/definition/detail/weak_ref.hpp>
 #include <otf2xx/writer/fwd.hpp>
 
-#include <cmath>
-#include <complex>
-#include <cstdint>
-#include <vector>
-
 namespace otf2
 {
 namespace event
 {
-
-    namespace detail
-    {
-        /**
-         * \brief A proxy class that allows type safe access to a metric value
-         *
-         * For performance reasons, the types and values of an event's metric
-         * values are stored in separate locations. This proxy class allows to
-         * set and retrieve a value with the correct type.
-         */
-        template <bool IsMutable>
-        class base_typed_value_proxy
-        {
-        public:
-            using type_type =
-                typename std::conditional<IsMutable, OTF2_Type, const OTF2_Type>::type;
-
-            using metric_value_type = typename std::conditional<IsMutable, OTF2_MetricValue,
-                                                                const OTF2_MetricValue>::type;
-
-        public:
-            base_typed_value_proxy(type_type& type, metric_value_type& value)
-            : type_(type), value_(value)
-            {
-            }
-
-            double as_double() const
-            {
-                switch (type())
-                {
-                case otf2::common::type::Double:
-                    return static_cast<double>(value_.floating_point);
-                case otf2::common::type::int64:
-                    return static_cast<double>(value_.signed_int);
-                case otf2::common::type::uint64:
-                    return static_cast<double>(value_.unsigned_int);
-                default:
-                    make_exception("Unexpected type given in metric member");
-                }
-
-                return 0;
-            }
-
-            std::int64_t as_int64() const
-            {
-                switch (type())
-                {
-                case otf2::common::type::Double:
-                    return static_cast<std::int64_t>(value_.floating_point);
-                case otf2::common::type::int64:
-                    return static_cast<std::int64_t>(value_.signed_int);
-                case otf2::common::type::uint64:
-                    return static_cast<std::int64_t>(value_.unsigned_int);
-                default:
-                    make_exception("Unexpected type given in metric member");
-                }
-
-                return 0;
-            }
-
-            std::uint64_t as_uint64() const
-            {
-                switch (type())
-                {
-                case otf2::common::type::Double:
-                    return static_cast<std::uint64_t>(value_.floating_point);
-                case otf2::common::type::int64:
-                    return static_cast<std::uint64_t>(value_.signed_int);
-                case otf2::common::type::uint64:
-                    return static_cast<std::uint64_t>(value_.unsigned_int);
-                default:
-                    make_exception("Unexpected type given in metric member");
-                }
-
-                return 0;
-            }
-
-            template <typename T, bool Mutable = IsMutable>
-            std::enable_if_t<Mutable && std::is_arithmetic<T>::value> value(T x)
-            {
-                switch (type())
-                {
-                case otf2::common::type::Double:
-                    value_.floating_point = static_cast<double>(x);
-                    break;
-                case otf2::common::type::int64:
-                    value_.signed_int = static_cast<std::int64_t>(x);
-                    break;
-                case otf2::common::type::uint64:
-                    value_.unsigned_int = static_cast<std::uint64_t>(x);
-                    break;
-                default:
-                    make_exception("Unexpected type given in metric member");
-                }
-            }
-
-            template <typename T>
-            base_typed_value_proxy operator=(T x)
-            {
-                value(x);
-                return { *this };
-            }
-
-            otf2::common::type type() const
-            {
-                return static_cast<otf2::common::type>(type_);
-            }
-
-            template <bool Mutable = IsMutable>
-            std::enable_if_t<Mutable> type(otf2::common::type type_id)
-            {
-                type_ = static_cast<OTF2_Type>(type_id);
-            }
-
-            template <bool Mutable = IsMutable>
-            std::enable_if_t<Mutable> type(OTF2_Type type_id)
-            {
-                type_ = type_id;
-            }
-
-        private:
-            type_type& type_;
-            metric_value_type& value_;
-        };
-
-        using typed_value_proxy = base_typed_value_proxy<true>;
-        using const_typed_value_proxy = base_typed_value_proxy<false>;
-    } // namespace detail
-
     class metric : public base<metric>
     {
     public:
-        /**
-         * \brief A proxy class allowing type safe, correctly scaled access to a
-         *        metric value
-         */
-        template <bool IsMutable>
-        class base_value_proxy
-        {
-            template <typename T>
-            T scale(T x) const
-            {
-                using value_base_type = otf2::definition::metric_member::value_base_type;
-
-                int base;
-                switch (metric_->value_base())
-                {
-                case value_base_type::binary:
-                    base = 2;
-                    break;
-                case value_base_type::decimal:
-                    base = 10;
-                    break;
-                }
-                return x * std::pow(base, metric_->value_exponent());
-            }
-
-        public:
-            using typed_value_proxy = detail::base_typed_value_proxy<IsMutable>;
-
-            // This is OTF2_Type, or const OTF2_Type if IsMutable == true
-            using type_type = typename typed_value_proxy::type_type;
-
-            // ... and the same thing for OTF2_MetricValue
-            using metric_value_type = typename typed_value_proxy::metric_value_type;
-
-            base_value_proxy(
-                type_type& type, metric_value_type& value,
-                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
-            : value_(type, value), metric_(metric)
-            {
-            }
-
-            base_value_proxy(
-                const typed_value_proxy& value,
-                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
-            : value_(value), metric_(metric)
-            {
-            }
-
-            base_value_proxy(
-                typed_value_proxy&& value,
-                otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric)
-            : value_(std::move(value)), metric_(metric)
-            {
-            }
-
-            double as_double() const
-            {
-                return scale<double>(value_.as_double());
-            }
-
-            std::int64_t as_int64() const
-            {
-                return scale<std::int64_t>(value_.as_int64());
-            }
-
-            std::uint64_t as_uint64() const
-            {
-                return scale<std::uint64_t>(value_.as_uint64());
-            }
-
-            template <typename T, bool Mutable = IsMutable>
-            std::enable_if_t<Mutable> set(T x)
-            {
-                value_.value(x);
-            }
-
-            template <typename T, bool Mutable = IsMutable>
-            std::enable_if_t<Mutable, base_value_proxy&> operator=(T x)
-            {
-                value_ = x;
-                return *this;
-            }
-
-            otf2::common::type type() const
-            {
-                assert(value_.type() == metric_->value_type());
-
-                return value_.type();
-            }
-
-        private:
-            typed_value_proxy value_;
-            otf2::definition::detail::weak_ref<otf2::definition::metric_member> metric_;
-        };
-
-        class metric_values
-        {
-        public:
-            metric_values(std::vector<OTF2_Type>&& type_ids,
-                          std::vector<OTF2_MetricValue>&& metric_values)
-            : type_ids_(std::move(type_ids)), values_(std::move(metric_values))
-            {
-                if (type_ids_.size() != values_.size())
-                {
-                    make_exception(
-                        "attempting to construct metric_values from data of different sizes");
-                }
-            }
-
-            metric_values(const otf2::definition::metric_class& metric_class)
-            : type_ids_(metric_class.size()), values_(metric_class.size())
-            {
-                for (std::size_t i = 0; i < metric_class.size(); ++i)
-                {
-                    type_ids_[i] = static_cast<OTF2_Type>(metric_class[i].value_type());
-                }
-            }
-
-            std::size_t size() const
-            {
-                return type_ids_.size();
-            }
-
-            const std::vector<OTF2_Type>& type_ids() const
-            {
-                return type_ids_;
-            }
-
-            const std::vector<OTF2_MetricValue>& values() const
-            {
-                return values_;
-            }
-
-            detail::typed_value_proxy at(std::size_t index)
-            {
-                if (index >= size())
-                {
-                    throw std::out_of_range("Out of bounds access in metric_values");
-                }
-
-                return { type_ids_[index], values_[index] };
-            }
-
-            detail::const_typed_value_proxy at(std::size_t index) const
-            {
-                if (index >= size())
-                {
-                    throw std::out_of_range("Out of bounds access in metric_values");
-                }
-
-                return { type_ids_[index], values_[index] };
-            }
-
-            detail::typed_value_proxy operator[](std::size_t index)
-            {
-                return { type_ids_[index], values_[index] };
-            }
-
-            detail::const_typed_value_proxy operator[](std::size_t index) const
-            {
-                return { type_ids_[index], values_[index] };
-            }
-
-            template <bool IsMutable>
-            class base_iterator
-            {
-            public:
-                using value_type = detail::base_typed_value_proxy<IsMutable>;
-
-                using type_type = typename value_type::type_type;
-                using metric_value_type = typename value_type::metric_value_type;
-
-            private:
-                friend metric_values;
-
-                base_iterator(type_type* type_id, metric_value_type* value)
-                : type_ptr_(type_id), value_ptr_(value)
-                {
-                }
-
-            public:
-                bool operator==(const base_iterator& rhs) const
-                {
-                    return type_ptr_ == rhs.type_ptr_ && value_ptr_ == rhs.value_ptr_;
-                }
-
-                bool operator!=(const base_iterator& rhs) const
-                {
-                    return !(*this == rhs);
-                }
-
-                value_type operator*()
-                {
-                    return { *type_ptr_, *value_ptr_ };
-                }
-
-                base_iterator& operator++()
-                {
-                    ++type_ptr_;
-                    ++value_ptr_;
-                    return *this;
-                }
-
-                base_iterator operator++(int)
-                {
-                    return { type_ptr_++, value_ptr_++ };
-                }
-
-            private:
-                type_type* type_ptr_;
-                metric_value_type* value_ptr_;
-            };
-
-            using iterator = base_iterator<true>;
-            using const_iterator = base_iterator<false>;
-
-            const_iterator begin() const
-            {
-                return const_iterator{ type_ids_.data(), values_.data() };
-            }
-
-            iterator begin()
-            {
-                return iterator{ type_ids_.data(), values_.data() };
-            }
-
-            const_iterator end() const
-            {
-                return const_iterator{ type_ids_.data() + size(), values_.data() + size() };
-            }
-
-            iterator end()
-            {
-                return iterator{ type_ids_.data() + size(), values_.data() + size() };
-            }
-
-        private:
-            std::vector<OTF2_Type> type_ids_;
-            std::vector<OTF2_MetricValue> values_;
-        };
-
-        using value_proxy = base_value_proxy<true>;
-        using const_value_proxy = base_value_proxy<false>;
+        using values = detail::metric_values;
+        using value_proxy = detail::value_proxy;
+        using const_value_proxy = detail::const_value_proxy;
 
         metric() = default;
 
         // construct with values
         metric(otf2::chrono::time_point timestamp, const otf2::definition::metric_class& metric_c,
-               metric_values&& values)
+               values&& values)
         : base<metric>(timestamp), metric_class_(metric_c), metric_instance_(),
           values_(std::move(values))
         {
         }
 
         metric(OTF2_AttributeList* al, otf2::chrono::time_point timestamp,
-               const otf2::definition::metric_class& metric_c, metric_values&& values)
+               const otf2::definition::metric_class& metric_c, values&& values)
         : base<metric>(al, timestamp), metric_class_(metric_c), metric_instance_(),
           values_(std::move(values))
         {
@@ -453,14 +80,14 @@ namespace event
 
         // construct with values
         metric(otf2::chrono::time_point timestamp,
-               const otf2::definition::metric_instance& metric_c, metric_values&& values)
+               const otf2::definition::metric_instance& metric_c, values&& values)
         : base<metric>(timestamp), metric_class_(), metric_instance_(metric_c),
           values_(std::move(values))
         {
         }
 
         metric(OTF2_AttributeList* al, otf2::chrono::time_point timestamp,
-               const otf2::definition::metric_instance& metric_c, metric_values&& values)
+               const otf2::definition::metric_instance& metric_c, values&& values)
         : base<metric>(al, timestamp), metric_class_(), metric_instance_(metric_c),
           values_(std::move(values))
         {
@@ -487,18 +114,18 @@ namespace event
         }
 
         /// construct without referencing a metric class or a metric instance
-        metric(OTF2_AttributeList* al, otf2::chrono::time_point timestamp, metric_values&& values)
+        metric(OTF2_AttributeList* al, otf2::chrono::time_point timestamp, values&& values)
         : base<metric>(al, timestamp), metric_class_(), metric_instance_(),
           values_(std::move(values))
         {
         }
 
-        metric_values& raw_values()
+        values& raw_values()
         {
             return values_;
         }
 
-        const metric_values& raw_values() const
+        const values& raw_values() const
         {
             return values_;
         }
@@ -602,7 +229,7 @@ namespace event
     private:
         weak_ref<otf2::definition::metric_class> metric_class_;
         weak_ref<otf2::definition::metric_instance> metric_instance_;
-        metric_values values_;
+        values values_;
     };
 } // namespace event
 } // namespace otf2

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -281,10 +281,7 @@ namespace event
             return static_cast<bool>(metric_class_);
         }
 
-        template <typename Definition>
-        using weak_ref = otf2::definition::detail::weak_ref<Definition>;
-
-        weak_ref<otf2::definition::metric_class> metric_class() const
+        otf2::definition::metric_class metric_class() const
         {
             return metric_class_;
         }
@@ -300,7 +297,7 @@ namespace event
             return static_cast<bool>(metric_instance_);
         }
 
-        weak_ref<otf2::definition::metric_instance> metric_instance() const
+        otf2::definition::metric_instance metric_instance() const
         {
             return metric_instance_;
         }
@@ -311,19 +308,15 @@ namespace event
             metric_instance_ = mi;
         }
 
-        weak_ref<otf2::definition::metric_class> resolve_metric_class() const
+        otf2::definition::metric_class resolve_metric_class() const
         {
-            assert(((void)"Malformed metric event: does reference neither metric class nor metric "
-                          "instance!",
-                    has_metric_class() || has_metric_instance()));
-
-            if (has_metric_class())
+            if (has_metric_instance())
             {
-                return metric_class_;
+                return metric_instance_->metric_class();
             }
             else
             {
-                return metric_instance_->metric_class();
+                return metric_class_;
             }
         }
 

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -505,7 +505,7 @@ namespace event
 
         value_proxy get_value_at(std::size_t index)
         {
-            auto metric_class = resolve_metric_class_ref();
+            auto metric_class = resolve_weak_ref_to_metric_class();
 
             assert(static_cast<bool>(metric_class));
 
@@ -514,7 +514,7 @@ namespace event
 
         const_value_proxy get_value_at(std::size_t index) const
         {
-            auto metric_class = resolve_metric_class_ref();
+            auto metric_class = resolve_weak_ref_to_metric_class();
 
             assert(static_cast<bool>(metric_class));
 
@@ -523,7 +523,7 @@ namespace event
 
         value_proxy get_value_for(const otf2::definition::metric_member& member)
         {
-            auto metric_class = this->resolve_metric_class_ref();
+            auto metric_class = resolve_weak_ref_to_metric_class();
 
             // TODO: maybe check if metric_class is undefined? This might happen
             // if the event was constructed without a reference to a metric
@@ -578,7 +578,7 @@ namespace event
 
         otf2::definition::metric_class resolve_metric_class() const
         {
-            return otf2::definition::metric_class{ resolve_metric_class_ref() };
+            return otf2::definition::metric_class{ resolve_weak_ref_to_metric_class() };
         }
 
         friend class otf2::writer::local;
@@ -587,7 +587,7 @@ namespace event
         template <typename Definition>
         using weak_ref = otf2::definition::detail::weak_ref<Definition>;
 
-        weak_ref<otf2::definition::metric_class> resolve_metric_class_ref() const
+        weak_ref<otf2::definition::metric_class> resolve_weak_ref_to_metric_class() const
         {
             if (has_metric_instance())
             {

--- a/include/otf2xx/event/metric.hpp
+++ b/include/otf2xx/event/metric.hpp
@@ -333,6 +333,11 @@ namespace event
                 return { type_ids_[index], values_[index] };
             }
 
+            detail::const_typed_value_proxy operator[](std::size_t index) const
+            {
+                return { type_ids_[index], values_[index] };
+            }
+
             detail::typed_value_proxy operator[](std::size_t index)
             {
                 return { type_ids_[index], values_[index] };
@@ -413,6 +418,24 @@ namespace event
         const metric_values& raw_values() const
         {
             return values_;
+        }
+
+        value_proxy get_value_at(std::size_t index)
+        {
+            auto metric_class = resolve_metric_class_ref();
+
+            assert(metric_class->is_valid());
+
+            return value_proxy(values_[index], (*metric_class)[index]);
+        }
+
+        const_value_proxy get_value_at(std::size_t index) const
+        {
+            auto metric_class = resolve_metric_class_ref();
+
+            assert(metric_class->is_valid());
+
+            return const_value_proxy(values_[index], (*metric_class)[index]);
         }
 
         value_proxy get_value_for(const otf2::definition::metric_member& member)

--- a/include/otf2xx/writer/local.hpp
+++ b/include/otf2xx/writer/local.hpp
@@ -173,9 +173,9 @@ namespace writer
                 ref = metric.metric_class_->ref();
             }
 
-            std::size_t num_members = metric.values().size();
-            const auto& type_ids = metric.values().type_ids();
-            const auto& metric_values = metric.values().values();
+            std::size_t num_members = metric.raw_values().size();
+            const auto& type_ids = metric.raw_values().type_ids();
+            const auto& metric_values = metric.raw_values().values();
 
             check(OTF2_EvtWriter_Metric(evt_wrt_, metric.attribute_list().get(),
                                         convert(metric.timestamp()), ref, num_members,

--- a/include/otf2xx/writer/local.hpp
+++ b/include/otf2xx/writer/local.hpp
@@ -164,7 +164,7 @@ namespace writer
         {
             otf2::reference<otf2::definition::detail::metric_base>::ref_type metric;
 
-            if (data.metric_instance_)
+            if (data.has_metric_instance())
             {
                 metric = data.metric_instance_->ref();
             }
@@ -174,19 +174,12 @@ namespace writer
             }
 
             std::size_t num_members = data.values().size();
-
-            type_ids_.resize(num_members);
-            values_.resize(num_members);
-
-            for (std::size_t i = 0; i < num_members; i++)
-            {
-                type_ids_[i] = static_cast<OTF2_Type>(data.values()[i].metric->value_type());
-                values_[i] = data.values()[i].value;
-            }
+            const auto& type_ids = data.values().type_ids();
+            const auto& metric_values = data.values().values();
 
             check(OTF2_EvtWriter_Metric(evt_wrt_, data.attribute_list().get(),
                                         convert(data.timestamp()), metric, num_members,
-                                        type_ids_.data(), values_.data()),
+                                        type_ids.data(), metric_values.data()),
                   "Couldn't write event to local event writer.");
             location_.event_written();
         }
@@ -611,9 +604,6 @@ namespace writer
         OTF2_Archive* ar_;
         OTF2_DefWriter* def_wrt_;
         OTF2_EvtWriter* evt_wrt_;
-
-        std::vector<OTF2_Type> type_ids_;
-        std::vector<OTF2_MetricValue> values_;
     };
 
     template <typename Record>

--- a/include/otf2xx/writer/local.hpp
+++ b/include/otf2xx/writer/local.hpp
@@ -160,25 +160,25 @@ namespace writer
             location_.event_written();
         }
 
-        void write(const otf2::event::metric& data)
+        void write(const otf2::event::metric& metric)
         {
-            otf2::reference<otf2::definition::detail::metric_base>::ref_type metric;
+            otf2::reference<otf2::definition::detail::metric_base>::ref_type ref;
 
-            if (data.has_metric_instance())
+            if (metric.has_metric_instance())
             {
-                metric = data.metric_instance_->ref();
+                ref = metric.metric_instance_->ref();
             }
             else
             {
-                metric = data.metric_class_->ref();
+                ref = metric.metric_class_->ref();
             }
 
-            std::size_t num_members = data.values().size();
-            const auto& type_ids = data.values().type_ids();
-            const auto& metric_values = data.values().values();
+            std::size_t num_members = metric.values().size();
+            const auto& type_ids = metric.values().type_ids();
+            const auto& metric_values = metric.values().values();
 
-            check(OTF2_EvtWriter_Metric(evt_wrt_, data.attribute_list().get(),
-                                        convert(data.timestamp()), metric, num_members,
+            check(OTF2_EvtWriter_Metric(evt_wrt_, metric.attribute_list().get(),
+                                        convert(metric.timestamp()), ref, num_members,
                                         type_ids.data(), metric_values.data()),
                   "Couldn't write event to local event writer.");
             location_.event_written();

--- a/src/reader/callback/events.cpp
+++ b/src/reader/callback/events.cpp
@@ -143,7 +143,7 @@ namespace reader
                     otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
                         time - reader->clock_properties().start_time().count()));
 
-                otf2::event::metric::metric_values metric_values{
+                otf2::event::metric::values metric_values{
                     std::vector<OTF2_Type>{ typeIDs, typeIDs + numberOfMetrics },
                     std::vector<OTF2_MetricValue>{ metricValues, metricValues + numberOfMetrics }
                 };

--- a/src/reader/callback/events.cpp
+++ b/src/reader/callback/events.cpp
@@ -148,30 +148,23 @@ namespace reader
                     std::vector<OTF2_MetricValue>{ metricValues, metricValues + numberOfMetrics }
                 };
 
+                otf2::event::metric metric_event{ attributeList, timestamp,
+                                                  std::move(metric_values) };
+
                 // assumes a valid trace file
-                if (reader->metric_classes().count(metric))
+                auto it = reader->metric_classes().find(metric);
+                if (it != reader->metric_classes().end())
                 {
                     // create metric_event that references a metric_class
-                    const otf2::definition::metric_class& metric_class =
-                        reader->metric_classes()[metric];
-
-                    otf2::event::metric metric_event{ attributeList, timestamp, metric_class,
-                                                      std::move(metric_values) };
-
-                    reader->callback().event(reader->locations()[locationID], metric_event);
+                    metric_event.metric_class(*it);
                 }
                 else
                 {
                     // create metric_event that references a metric_instance
-                    const otf2::definition::metric_instance& metric_instance =
-                        reader->metric_instances()[metric];
-
-                    otf2::event::metric metric_event{ attributeList, timestamp, metric_instance,
-                                                      std::move(metric_values) };
-
-                    reader->callback().event(reader->locations()[locationID], metric_event);
+                    metric_event.metric_instance(reader->metric_instances()[metric]);
                 }
 
+                reader->callback().event(reader->locations()[locationID], metric_event);
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
 

--- a/src/reader/callback/events.cpp
+++ b/src/reader/callback/events.cpp
@@ -674,21 +674,21 @@ namespace reader
             OTF2_CallbackCode io_create_handle(OTF2_LocationRef locationID, OTF2_TimeStamp time,
                                                void* userData, OTF2_AttributeList* attributeList,
                                                OTF2_IoHandleRef handle, OTF2_IoAccessMode mode,
-                                               OTF2_IoCreationFlag creationFlags, OTF2_IoStatusFlag statusFlags)
+                                               OTF2_IoCreationFlag creationFlags,
+                                               OTF2_IoStatusFlag statusFlags)
             {
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_create_handle(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            static_cast<otf2::common::io_access_mode_type>(mode),
-                            static_cast<otf2::common::io_creation_flag_type>(creationFlags),
-                            static_cast<otf2::common::io_status_flag_type>(statusFlags)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_create_handle(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle],
+                        static_cast<otf2::common::io_access_mode_type>(mode),
+                        static_cast<otf2::common::io_creation_flag_type>(creationFlags),
+                        static_cast<otf2::common::io_status_flag_type>(statusFlags)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -700,34 +700,32 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_destroy_handle(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle]
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_destroy_handle(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle]));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
 
             OTF2_CallbackCode io_duplicate_handle(OTF2_LocationRef locationID, OTF2_TimeStamp time,
                                                   void* userData, OTF2_AttributeList* attributeList,
-                                                  OTF2_IoHandleRef oldHandle, OTF2_IoHandleRef newHandle,
+                                                  OTF2_IoHandleRef oldHandle,
+                                                  OTF2_IoHandleRef newHandle,
                                                   OTF2_IoStatusFlag statusFlags)
             {
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_duplicate_handle(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[oldHandle],
-                            reader->io_handles()[newHandle],
-                            static_cast<otf2::common::io_status_flag_type>(statusFlags)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_duplicate_handle(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[oldHandle], reader->io_handles()[newHandle],
+                        static_cast<otf2::common::io_status_flag_type>(statusFlags)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -740,35 +738,33 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_seek(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            offsetRequest,
-                            static_cast<otf2::common::io_seek_option_type>(whence),
-                            offsetResult
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_seek(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle], offsetRequest,
+                        static_cast<otf2::common::io_seek_option_type>(whence), offsetResult));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
 
-            OTF2_CallbackCode io_change_status_flag(OTF2_LocationRef locationID, OTF2_TimeStamp time,
-                                                    void* userData, OTF2_AttributeList* attributeList,
-                                                    OTF2_IoHandleRef handle, OTF2_IoStatusFlag statusFlags)
+            OTF2_CallbackCode io_change_status_flag(OTF2_LocationRef locationID,
+                                                    OTF2_TimeStamp time, void* userData,
+                                                    OTF2_AttributeList* attributeList,
+                                                    OTF2_IoHandleRef handle,
+                                                    OTF2_IoStatusFlag statusFlags)
             {
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_change_status_flag(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            static_cast<otf2::common::io_status_flag_type>(statusFlags)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_change_status_flag(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle],
+                        static_cast<otf2::common::io_status_flag_type>(statusFlags)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -780,14 +776,12 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_delete_file(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_paradigms()[ioParadigm],
-                            reader->io_files()[file]
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_delete_file(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_paradigms()[ioParadigm], reader->io_files()[file]));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -795,8 +789,8 @@ namespace reader
             OTF2_CallbackCode io_operation_begin(OTF2_LocationRef locationId, OTF2_TimeStamp time,
                                                  void* userData, OTF2_AttributeList* attributeList,
                                                  OTF2_IoHandleRef handle, OTF2_IoOperationMode mode,
-                                                 OTF2_IoOperationFlag operationFlags, uint64_t bytesRequest,
-                                                 uint64_t matchingId)
+                                                 OTF2_IoOperationFlag operationFlags,
+                                                 uint64_t bytesRequest, uint64_t matchingId)
             {
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
@@ -805,7 +799,7 @@ namespace reader
                     otf2::event::io_operation_begin(
                         attributeList,
                         otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                time - reader->clock_properties().start_time().count())),
+                            time - reader->clock_properties().start_time().count())),
                         reader->io_handles()[handle],
                         static_cast<otf2::common::io_operation_mode_type>(mode),
                         static_cast<otf2::common::io_operation_flag_type>(operationFlags),
@@ -821,13 +815,12 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_operation_test(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle], matchingId
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_operation_test(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle], matchingId));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -839,37 +832,37 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_operation_issued(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle], matchingId
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_operation_issued(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle], matchingId));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
 
-            OTF2_CallbackCode io_operation_cancelled(OTF2_LocationRef locationID, OTF2_TimeStamp time,
-                                                     void* userData, OTF2_AttributeList* attributeList,
+            OTF2_CallbackCode io_operation_cancelled(OTF2_LocationRef locationID,
+                                                     OTF2_TimeStamp time, void* userData,
+                                                     OTF2_AttributeList* attributeList,
                                                      OTF2_IoHandleRef handle, uint64_t matchingId)
             {
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_operation_cancelled(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle], matchingId
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_operation_cancelled(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle], matchingId));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
 
-            OTF2_CallbackCode io_operation_complete(OTF2_LocationRef locationId, OTF2_TimeStamp time,
-                                                    void* userData, OTF2_AttributeList* attributeList,
+            OTF2_CallbackCode io_operation_complete(OTF2_LocationRef locationId,
+                                                    OTF2_TimeStamp time, void* userData,
+                                                    OTF2_AttributeList* attributeList,
                                                     OTF2_IoHandleRef handle, uint64_t bytesRequest,
                                                     uint64_t matchingId)
             {
@@ -880,7 +873,7 @@ namespace reader
                     otf2::event::io_operation_complete(
                         attributeList,
                         otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                time - reader->clock_properties().start_time().count())),
+                            time - reader->clock_properties().start_time().count())),
                         reader->io_handles()[handle], bytesRequest, matchingId));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
@@ -893,14 +886,13 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_acquire_lock(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            static_cast<otf2::common::lock_type>(lockType)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_acquire_lock(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle],
+                        static_cast<otf2::common::lock_type>(lockType)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -912,14 +904,13 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_release_lock(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            static_cast<otf2::common::lock_type>(lockType)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_release_lock(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle],
+                        static_cast<otf2::common::lock_type>(lockType)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -931,14 +922,13 @@ namespace reader
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 reader->callback().event(
-                        reader->locations()[locationID],
-                        otf2::event::io_try_lock(
-                            attributeList,
-                            otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
-                                    time - reader->clock_properties().start_time().count())),
-                            reader->io_handles()[handle],
-                            static_cast<otf2::common::lock_type>(lockType)
-                ));
+                    reader->locations()[locationID],
+                    otf2::event::io_try_lock(
+                        attributeList,
+                        otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
+                            time - reader->clock_properties().start_time().count())),
+                        reader->io_handles()[handle],
+                        static_cast<otf2::common::lock_type>(lockType)));
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
@@ -956,7 +946,7 @@ namespace reader
 
                 return static_cast<OTF2_CallbackCode>(OTF2_SUCCESS);
             }
-        }
-    }
-}
-} // namespace otf2::reader::detail::event
+        } // namespace event
+    }     // namespace detail
+} // namespace reader
+} // namespace otf2

--- a/src/reader/callback/events.cpp
+++ b/src/reader/callback/events.cpp
@@ -131,8 +131,6 @@ namespace reader
                                      OTF2_MetricRef metric, uint8_t numberOfMetrics,
                                      const OTF2_Type* typeIDs, const OTF2_MetricValue* metricValues)
             {
-                // typeID parameter is ignored, as it's redundant with metric_member
-
                 otf2::reader::reader* reader = static_cast<otf2::reader::reader*>(userData);
 
                 // WORKAROUND for broken Score-P traces
@@ -145,8 +143,10 @@ namespace reader
                     otf2::chrono::convert(reader->ticks_per_second())(otf2::chrono::ticks(
                         time - reader->clock_properties().start_time().count()));
 
-                otf2::event::metric::metric_values metric_values{ typeIDs, metricValues,
-                                                                  numberOfMetrics };
+                otf2::event::metric::metric_values metric_values{
+                    std::vector<OTF2_Type>{ typeIDs, typeIDs + numberOfMetrics },
+                    std::vector<OTF2_MetricValue>{ metricValues, metricValues + numberOfMetrics }
+                };
 
                 // assumes a valid trace file
                 if (reader->metric_classes().count(metric))


### PR DESCRIPTION
Previously, `otf2::event::metric` stored its metric values as pairs of
referenced metric members and metric values.  This incurred overhead
when writing the event to a trace because of the following reasons:

1.  `OTF2_EvtWriter_Metric` expects two continuous arrays, one for
        metric values and one for the corresponding `OTF2_TypeID`s.
        Each of them had to be created and copied from the pairs
        contained in a metric event.

2.  Each type ID had to be looked up in the referenced metric
        member.

With this commit, `otf2::event::metric` stores both metric values and type
IDs directly in two continuous buffers which.  The contents of these
buffers is copied exactly once from the OTF2 interface; when writing
an event to a trace, no additional copy operations are required.

It is still possible to obtain a `otf2::event::metric::value_container`
from a metric; they are created on-demand an will still contain a
refercence to metric member.

NOTE: this commit makes **BREAKING CHANGES** as the constructor for metric
events has changed.