### PR TITLE
Update CMake and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 
-sudo: required
+sudo: false
 dist: trusty
 
 matrix:
@@ -11,10 +11,8 @@ matrix:
       addons:
         apt:
           packages:
-            - gcc-7
             - g++-7
             - cmake
-            - cmake-data
           sources: &sources
             - ubuntu-toolchain-r-test
     - os: linux
@@ -23,10 +21,8 @@ matrix:
       addons:
         apt:
           packages:
-            - gcc-6
             - g++-6
             - cmake
-            - cmake-data
           sources: *sources
     - os: linux
       env: CXX="clang++-4.0" CC="clang-4.0"
@@ -37,7 +33,6 @@ matrix:
             - clang-4.0
             - g++-5
             - cmake
-            - cmake-data
           sources:
             - llvm-toolchain-trusty-4.0
             - ubuntu-toolchain-r-test
@@ -50,27 +45,34 @@ matrix:
             - clang-5.0
             - g++-5
             - cmake
-            - cmake-data
           sources:
             - llvm-toolchain-trusty-5.0
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports
     - os: osx
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode8.3
     - os: osx
       osx_image: xcode9.3
-before_script:
-  - wget http://www.vi-hps.org/upload/packages/otf2/otf2-2.1.tar.gz
-  - tar -xf otf2-2.1.tar.gz
-  - cd otf2-2.1
-  - ./configure --prefix=/usr/local
-  - make
-  - sudo make install
-  - cd ..
-  - cmake --version
-  - cmake .
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/deps/otf2-2.1
+
+install:
+  - OTF2_VERSION=2.1 # Update cache too when changing this!
+  - OTF2_DIR=${TRAVIS_BUILD_DIR}/deps/otf2-${OTF2_VERSION}
+  - |
+    if [ -z "$(ls -A ${OTF2_DIR})" ]; then
+      wget http://www.vi-hps.org/upload/packages/otf2/otf2-${OTF2_VERSION}.tar.gz
+      tar -xf otf2-${OTF2_VERSION}.tar.gz
+      (cd otf2-${OTF2_VERSION} && ./configure --prefix=${OTF2_DIR} && make -j2 install)
+    fi
+  - export CMAKE_PREFIX_PATH=${OTF2_DIR}:${CMAKE_PREFIX_PATH}
+
 script:
-  - make
+  - cmake --version
+  - mkdir build && cd build
+  - cmake ..
+  - make -j2
   - ctest -V .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ cmake_minimum_required(VERSION 3.5)
 
 set(otf2xx_VERSION 1.0)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake;${CMAKE_MODULE_PATH}")
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(OTF2 8.0.1 EXACT)
 
 if (NOT OTF2_FOUND)
@@ -43,27 +43,18 @@ if (NOT OTF2_FOUND)
     "Available from: http://www.vi-hps.org/upload/packages/otf2/otf2-2.1.tar.gz")
 endif()
 
-if(NOT OTF2XX_CHRONO_DURATION_TYPE)
-    set(OTF2XX_CHRONO_DURATION_TYPE "picoseconds")
-endif()
-
-set(OTF2XX_CHRONO_DURATION_TYPE ${OTF2XX_CHRONO_DURATION_TYPE} CACHE STRING "The used underlying type for otf2::chrono::duration.")
-set_property(CACHE OTF2XX_CHRONO_DURATION_TYPE PROPERTY STRINGS "nanoseconds" "picoseconds")
-if(${OTF2XX_CHRONO_DURATION_TYPE} STREQUAL "nanoseconds" OR ${OTF2XX_CHRONO_DURATION_TYPE} STREQUAL "picoseconds")
+set(OTF2XX_CHRONO_DURATION_TYPE "picoseconds" CACHE STRING "The used underlying type for otf2::chrono::duration.")
+set(otf2xx_allowed_duration_types "nanoseconds" "picoseconds")
+set_property(CACHE OTF2XX_CHRONO_DURATION_TYPE PROPERTY STRINGS ${otf2xx_allowed_duration_types})
+if(OTF2XX_CHRONO_DURATION_TYPE IN_LIST otf2xx_allowed_duration_types)
     message(STATUS "OTF2xx uses '${OTF2XX_CHRONO_DURATION_TYPE}' as chrono duration type.")
 else()
-    message(SEND_ERROR "OTF2XX_CHRONO_DURATION_TYPE must be either nanoseconds or picoseconds")
+    message(SEND_ERROR "OTF2XX_CHRONO_DURATION_TYPE must be one of ${otf2xx_allowed_duration_types}")
 endif()
 
-if(NOT OTF2XX_WITH_MPI)
-    set(OTF2XX_WITH_MPI OFF)
-endif()
-option(OTF2XX_WITH_MPI "Whether OTF2xx should be build with MPI support or not. (Requires Boost.MPI)" ${OTF2XX_WITH_MPI})
-
-if(NOT OTF2XX_USE_STATIC_LIBS)
-    set(OTF2XX_USE_STATIC_LIBS ON)
-endif()
-option(OTF2XX_USE_STATIC_LIBS "Whether OTF2xx should be build static or not." ${OTF2XX_USE_STATIC_LIBS})
+option(OTF2XX_WITH_MPI "Whether OTF2xx should be build with MPI support or not. (Requires Boost.MPI)" OFF)
+option(OTF2XX_BUILD_SHARED_LIBS "Whether OTF2xx should be build shared or not." OFF)
+set(BUILD_SHARED_LIBS OTF2XX_BUILD_SHARED_LIBS) # Don't use cache variable so other projects are not influenced
 
 add_library(otf2xx-core INTERFACE)
 target_include_directories(otf2xx-core
@@ -116,12 +107,7 @@ if(OTF2XX_WITH_MPI)
     target_link_libraries(otf2xx-core INTERFACE Boost::mpi MPI::MPI_CXX)
 endif()
 
-set(READER_SRCS src/reader/callback/definitions.cpp src/reader/callback/events.cpp)
-if(OTF2XX_USE_STATIC_LIBS)
-    add_library(otf2xx-reader STATIC ${READER_SRCS})
-else()
-    add_library(otf2xx-reader SHARED ${READER_SRCS})
-endif()
+add_library(otf2xx-reader src/reader/callback/definitions.cpp src/reader/callback/events.cpp)
 target_link_libraries(otf2xx-reader
     PUBLIC
         otf2xx::Core)
@@ -178,6 +164,4 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     include(CTest)
     add_subdirectory(tests)
-else()
-    set_target_properties(otf2xx-reader PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()


### PR DESCRIPTION
Some minor simplifications.

Mostly: Values from cache variables take their value only when unset. So the explicit check and set of the default value is not required. And there is `BUILD_SHARED_LIBS` from CMake which does exactly that. The name of the OTF2xx variable was adapted (and uses better `build` instead of `use` to avoid confusion)