### PR TITLE
Simplify CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(otf2xx VERSION 1.0.0)
 
-list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(OTF2 8.0.1 EXACT)
 
 if (NOT OTF2_FOUND)
@@ -81,6 +81,18 @@ if(OTF2XX_WITH_MPI)
         INTERFACE
             OTF2XX_HAS_MPI
     )
+    find_package(Boost REQUIRED COMPONENTS mpi)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    if(NOT TARGET MPI::MPI_CXX) # For CMake < 3.9
+        add_library(MPI::MPI_CXX INTERFACE IMPORTED)
+        set_target_properties(MPI::MPI_CXX PROPERTIES
+            INTERFACE_COMPILE_OPTIONS "${MPI_CXX_COMPILE_FLAGS}"
+            INTERFACE_INCLUDE_DIRECTORIES "${MPI_CXX_INCLUDE_PATH}"
+            INTERFACE_LINK_LIBRARIES "${MPI_CXX_LIBRARIES}")
+        if(MPI_CXX_LINK_FLAGS)
+            set_property(TARGET MPI::MPI_CXX APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${MPI_CXX_LINK_FLAGS}")
+        endif()
+    endif()      
     target_link_libraries(otf2xx-core INTERFACE Boost::mpi MPI::MPI_CXX)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-project(otf2xx)
-
 cmake_minimum_required(VERSION 3.8)
 
-set(otf2xx_VERSION 1.0)
+project(otf2xx VERSION 1.0.0)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake;${CMAKE_MODULE_PATH}")
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(OTF2 8.0.1 EXACT)
 
 if (NOT OTF2_FOUND)
@@ -43,27 +41,23 @@ if (NOT OTF2_FOUND)
     "Available from: http://www.vi-hps.org/upload/packages/otf2/otf2-2.1.tar.gz")
 endif()
 
-if(NOT OTF2XX_CHRONO_DURATION_TYPE)
-    set(OTF2XX_CHRONO_DURATION_TYPE "picoseconds")
-endif()
-
-set(OTF2XX_CHRONO_DURATION_TYPE ${OTF2XX_CHRONO_DURATION_TYPE} CACHE STRING "The used underlying type for otf2::chrono::duration.")
-set_property(CACHE OTF2XX_CHRONO_DURATION_TYPE PROPERTY STRINGS "nanoseconds" "picoseconds")
-if(${OTF2XX_CHRONO_DURATION_TYPE} STREQUAL "nanoseconds" OR ${OTF2XX_CHRONO_DURATION_TYPE} STREQUAL "picoseconds")
+set(OTF2XX_CHRONO_DURATION_TYPE "picoseconds" CACHE STRING "The used underlying type for otf2::chrono::duration.")
+set(otf2xx_allowed_duration_types "nanoseconds" "picoseconds")
+set_property(CACHE OTF2XX_CHRONO_DURATION_TYPE PROPERTY STRINGS ${otf2xx_allowed_duration_types})
+if(OTF2XX_CHRONO_DURATION_TYPE IN_LIST otf2xx_allowed_duration_types)
     message(STATUS "OTF2xx uses '${OTF2XX_CHRONO_DURATION_TYPE}' as chrono duration type.")
 else()
-    message(SEND_ERROR "OTF2XX_CHRONO_DURATION_TYPE must be either nanoseconds or picoseconds")
+    message(SEND_ERROR "OTF2XX_CHRONO_DURATION_TYPE must be one of ${otf2xx_allowed_duration_types}")
 endif()
 
-if(NOT OTF2XX_WITH_MPI)
-    set(OTF2XX_WITH_MPI OFF)
+option(OTF2XX_WITH_MPI "Whether OTF2xx should be build with MPI support or not. (Requires Boost.MPI)" OFF)
+option(OTF2XX_USE_STATIC_LIBS "Whether OTF2xx should be build static or not." ON)
+# Set CMake variable which determines default library type
+if(OTF2XX_USE_STATIC_LIBS)
+    set(BUILD_SHARED_LIBS OFF)
+else()
+    set(BUILD_SHARED_LIBS ON)
 endif()
-option(OTF2XX_WITH_MPI "Whether OTF2xx should be build with MPI support or not. (Requires Boost.MPI)" ${OTF2XX_WITH_MPI})
-
-if(NOT OTF2XX_USE_STATIC_LIBS)
-    set(OTF2XX_USE_STATIC_LIBS ON)
-endif()
-option(OTF2XX_USE_STATIC_LIBS "Whether OTF2xx should be build static or not." ${OTF2XX_USE_STATIC_LIBS})
 
 add_library(otf2xx-core INTERFACE)
 target_include_directories(otf2xx-core
@@ -90,12 +84,7 @@ if(OTF2XX_WITH_MPI)
     target_link_libraries(otf2xx-core INTERFACE Boost::mpi MPI::MPI_CXX)
 endif()
 
-set(READER_SRCS src/reader/callback/definitions.cpp src/reader/callback/events.cpp)
-if(OTF2XX_USE_STATIC_LIBS)
-    add_library(otf2xx-reader STATIC ${READER_SRCS})
-else()
-    add_library(otf2xx-reader SHARED ${READER_SRCS})
-endif()
+add_library(otf2xx-reader src/reader/callback/definitions.cpp src/reader/callback/events.cpp)
 target_link_libraries(otf2xx-reader
     PUBLIC
         otf2xx::Core)
@@ -143,7 +132,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     include(CMakePackageConfigHelpers)
     write_basic_package_version_File("otf2xxConfigVersion.cmake"
-        VERSION ${otf2xx_VERSION}
+        VERSION ${PROJECT_VERSION}
         COMPATIBILITY SameMajorVersion
     )
     install(FILES "otf2xxConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/otf2xxConfigVersion.cmake"
@@ -152,6 +141,4 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     include(CTest)
     add_subdirectory(tests)
-else()
-    set_target_properties(otf2xx-reader PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,15 +83,8 @@ if(OTF2XX_WITH_MPI)
     )
     find_package(Boost REQUIRED COMPONENTS mpi)
     find_package(MPI REQUIRED COMPONENTS CXX)
-    if(NOT TARGET MPI::MPI_CXX) # For CMake < 3.9
-        add_library(MPI::MPI_CXX INTERFACE IMPORTED)
-        set_target_properties(MPI::MPI_CXX PROPERTIES
-            INTERFACE_COMPILE_OPTIONS "${MPI_CXX_COMPILE_FLAGS}"
-            INTERFACE_INCLUDE_DIRECTORIES "${MPI_CXX_INCLUDE_PATH}"
-            INTERFACE_LINK_LIBRARIES "${MPI_CXX_LIBRARIES}")
-        if(MPI_CXX_LINK_FLAGS)
-            set_property(TARGET MPI::MPI_CXX APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${MPI_CXX_LINK_FLAGS}")
-        endif()
+    if(NOT TARGET MPI::MPI_CXX)
+        message(FATAL_ERROR "MPI support requires CMake >= 3.9 or a properly defined MPI::MPI_CXX target")
     endif()      
     target_link_libraries(otf2xx-core INTERFACE Boost::mpi MPI::MPI_CXX)
 endif()


### PR DESCRIPTION
This is based on #15 

Some notes:

-  `cmake_minimum_required(VERSION 3.5)` has to be before `project` (it sets policies)
- `otf2xx_VERSION` is not required. CMake already has the generic `PROJECT_VERSION`
- `otf2xx_allowed_duration_types` introduced to avoid redundant mentioning of the values
- CMake variable `BUILD_SHARED_LIBS` is used to avoid duplicate code when adding libraries
- `EXCLUDE_FROM_ALL` is removed. It can be added by consumers in `add_subdirectory` (see https://github.com/tud-zih-energy/otf2xx/pull/15#discussion_r205072705) 

About the "code bloat" for the default values:

As discussed on the call I tested the order of `set(` and `set(...CACHE`). The CMake docu states, that the last `set` value is the valid one and a `set(...CACHE` does not set the cache variable when it exists. Hence this shorter code **does** change behavior as e.g. a `set(OTF2XX_CHRONO_DURATION_TYPE "nanoseconds")` before including this file is ignored. However in projects including this with `add_subdirectory` (only relevant use case) one can use `set(OTF2XX_CHRONO_DURATION_TYPE "nanoseconds" CACHE STRING "")` instead which I would prefer to avoid cluttering this CMakeLists.   
However I'm willing to change this if wanted, but please think about it.

Note that the current implementation is flawed:

> if(NOT OTF2XX_USE_STATIC_LIBS)
>     set(OTF2XX_USE_STATIC_LIBS ON)
> endif()

This will ALWAYS set the variable to `ON`. So at least for that the behavior would not change (except being changeable at all now) with the proposed change.