### PR TITLE
Add test with expected build failure

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,3 +45,19 @@ target_link_libraries(reader_test PRIVATE otf2xx::Reader)
 
 add_test(reader_test reader_test ${CMAKE_CURRENT_BINARY_DIR}/otf2xx_writer_trace/traces.otf2)
 set_property(TEST reader_test PROPERTY DEPENDS writer_test)
+
+function(add_failing_test name)
+    # Positive test to avoid unintended failures
+    add_executable(${name}-pass expected_failures/${name}.cpp)
+    target_link_libraries(${name}-pass PRIVATE otf2xx::Core)
+    # Provoke failure and compile only during test
+    add_executable(${name} EXCLUDE_FROM_ALL expected_failures/${name}.cpp)
+    target_link_libraries(${name} PRIVATE otf2xx::Core)
+    target_compile_definitions(${name} PRIVATE -DOTF2XX_MAKE_FAIL)
+    add_test(NAME metric_event_with_instance
+        COMMAND ${CMAKE_COMMAND} --build . --config $<CONFIG> --target metric_event_with_instance
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
+endfunction()
+
+add_failing_test(metric_event_with_instance)

--- a/tests/expected_failures/metric_event_with_instance.cpp
+++ b/tests/expected_failures/metric_event_with_instance.cpp
@@ -1,0 +1,21 @@
+#include <otf2xx/otf2.hpp>
+
+int main(){
+    namespace def = otf2::definition;
+    def::container<def::string> strings;
+    strings.add_definition({ 0, "42" });
+
+    def::system_tree_node root_node(0, strings[0], strings[0]);
+
+    def::location_group lg(0, strings[0], def::location_group::location_group_type::process, root_node);
+
+    def::location location(0, strings[0], lg, def::location::location_type::cpu_thread);
+    
+    def::metric_class mClass(0, otf2::common::metric_occurence::strict, otf2::common::recorder_kind::abstract);
+    def::metric_instance metric(0, mClass, location, location);
+
+#ifdef OTF2XX_MAKE_FAIL
+    // event::metric expects a metric_class not a metric_instance
+    otf2::event::metric ev(otf2::chrono::genesis(), metric);
+#endif
+}


### PR DESCRIPTION
Extracted from lo2us where a possible bug was identified.

According to the current source (https://github.com/tud-zih-energy/otf2xx/blob/9cca095c7ebf17fca92152f19dbca0d43136632e/include/otf2xx/event/metric.hpp#L97) a `metric_class` is expected but a `metric_instance` is passed. So this test should fail (compilation failure)

Question: Am I right and this compiles unexpectedly or is this a bug? Looking at the source I think there is a ctor missing.

Note: Please do not fix this yet. I have a fix in the pipeline (I accidentally discovered that where code stopped compiling after a cleanup)