### PR TITLE
Remove using namespace chrono_literals

### DIFF
--- a/include/otf2xx/chrono/duration.hpp
+++ b/include/otf2xx/chrono/duration.hpp
@@ -38,8 +38,6 @@
 #include <chrono>
 #include <iostream>
 
-using namespace std::literals::chrono_literals;
-
 namespace otf2
 {
 namespace chrono


### PR DESCRIPTION
This was done in global scope in a header file which is not required,
evil and can break builds.