### PR TITLE
Exception improvements

### DIFF
--- a/include/otf2xx/attribute_list.hpp
+++ b/include/otf2xx/attribute_list.hpp
@@ -665,7 +665,7 @@ private:
 
         if (attribute_list_ == nullptr)
         {
-            make_exception("Couldn't create a new attribute list.");
+            throw make_exception("Couldn't create a new attribute list.");
         }
 
         owned_ = true;

--- a/include/otf2xx/definition/clock_properties.hpp
+++ b/include/otf2xx/definition/clock_properties.hpp
@@ -63,7 +63,7 @@ namespace definition
         {
             if (end_time < start_time)
             {
-                make_exception("start_time must be before end_time");
+                throw make_exception("start_time must be before end_time");
             }
         }
 

--- a/include/otf2xx/definition/detail/calling_context_impl.hpp
+++ b/include/otf2xx/definition/detail/calling_context_impl.hpp
@@ -114,7 +114,7 @@ namespace definition
             {
                 if (!has_parent())
                 {
-                    make_exception("The calling context #", ref(), " hasn't got a parent.");
+                    throw make_exception("The calling context #", ref(), " hasn't got a parent.");
                 }
 
                 return parent_.get();

--- a/include/otf2xx/definition/detail/comm_impl.hpp
+++ b/include/otf2xx/definition/detail/comm_impl.hpp
@@ -115,7 +115,7 @@ namespace definition
             const otf2::definition::comm_group& group() const
             {
                 if (has_self_group())
-                    make_exception("The comm with id ", ref_.get(),
+                    throw make_exception("The comm with id ", ref_.get(),
                                    " hasn't got a group. It has a self group.");
 
                 return group_;
@@ -124,7 +124,7 @@ namespace definition
             const otf2::definition::comm_self_group& self_group() const
             {
                 if (!has_self_group())
-                    make_exception("The comm with id ", ref_.get(), " hasn't got a self group");
+                    throw make_exception("The comm with id ", ref_.get(), " hasn't got a self group");
 
                 return self_group_;
             }

--- a/include/otf2xx/definition/detail/io_handle_impl.hpp
+++ b/include/otf2xx/definition/detail/io_handle_impl.hpp
@@ -137,7 +137,7 @@ namespace definition
             {
                 if (!has_parent())
                 {
-                    make_exception("The io handle '", name().str(), "' hasn't got a parent.");
+                    throw make_exception("The io handle '", name().str(), "' hasn't got a parent.");
                 }
 
                 return parent_.get();

--- a/include/otf2xx/definition/detail/mapping_table_impl.hpp
+++ b/include/otf2xx/definition/detail/mapping_table_impl.hpp
@@ -69,7 +69,7 @@ namespace definition
             {
                 if (!id_map_)
                 {
-                    make_exception("Creation of IdMap failed.");
+                    throw make_exception("Creation of IdMap failed.");
                 }
             }
 
@@ -81,7 +81,7 @@ namespace definition
             {
                 if (!id_map_)
                 {
-                    make_exception("Creation of IdMap failed.");
+                    throw make_exception("Creation of IdMap failed.");
                 }
             }
 
@@ -93,7 +93,7 @@ namespace definition
             {
                 if (!id_map_)
                 {
-                    make_exception("Creation of IdMap failed.");
+                    throw make_exception("Creation of IdMap failed.");
                 }
             }
 

--- a/include/otf2xx/definition/detail/metric_instance_impl.hpp
+++ b/include/otf2xx/definition/detail/metric_instance_impl.hpp
@@ -157,7 +157,7 @@ namespace definition
                 if (group_scope_.is_valid())
                     return metric_scope::group;
 
-                make_exception("There is no valid scope definition for this metric instance.");
+                throw make_exception("There is no valid scope definition for this metric instance.");
 
                 return metric_scope::group;
             }

--- a/include/otf2xx/definition/detail/system_tree_node_impl.hpp
+++ b/include/otf2xx/definition/detail/system_tree_node_impl.hpp
@@ -116,7 +116,7 @@ namespace definition
             {
                 if (!has_parent())
                 {
-                    make_exception("The system tree node '", name().str(),
+                    throw make_exception("The system tree node '", name().str(),
                                    "' hasn't got a parent.");
                 }
 

--- a/include/otf2xx/event/buffer.hpp
+++ b/include/otf2xx/event/buffer.hpp
@@ -517,7 +517,7 @@ namespace event
                     break;
 
                 default:
-                    make_exception("Added unknown event type to event buffer");
+                    throw make_exception("Added unknown event type to event buffer");
                     break;
                 }
             }
@@ -706,7 +706,7 @@ namespace event
                     break;
 
                 default:
-                    make_exception("Added unknown event type to event buffer");
+                    throw make_exception("Added unknown event type to event buffer");
                     break;
                 }
 

--- a/include/otf2xx/event/detail/metric_values.hpp
+++ b/include/otf2xx/event/detail/metric_values.hpp
@@ -56,7 +56,7 @@ namespace event
             {
                 if (type_ids_.size() != values_.size())
                 {
-                    make_exception(
+                    throw make_exception(
                         "attempting to construct metric_values from data of different sizes");
                 }
             }

--- a/include/otf2xx/event/detail/value_proxy.hpp
+++ b/include/otf2xx/event/detail/value_proxy.hpp
@@ -84,7 +84,7 @@ namespace event
                 case otf2::common::type::uint64:
                     return static_cast<double>(value_.unsigned_int);
                 default:
-                    make_exception("Unexpected type given in metric member");
+                    throw make_exception("Unexpected type given in metric member");
                 }
 
                 return 0;
@@ -101,7 +101,7 @@ namespace event
                 case otf2::common::type::uint64:
                     return static_cast<std::int64_t>(value_.unsigned_int);
                 default:
-                    make_exception("Unexpected type given in metric member");
+                    throw make_exception("Unexpected type given in metric member");
                 }
 
                 return 0;
@@ -118,7 +118,7 @@ namespace event
                 case otf2::common::type::uint64:
                     return static_cast<std::uint64_t>(value_.unsigned_int);
                 default:
-                    make_exception("Unexpected type given in metric member");
+                    throw make_exception("Unexpected type given in metric member");
                 }
 
                 return 0;
@@ -139,7 +139,7 @@ namespace event
                     value_.unsigned_int = static_cast<std::uint64_t>(x);
                     break;
                 default:
-                    make_exception("Unexpected type given in metric member");
+                    throw make_exception("Unexpected type given in metric member");
                 }
             }
 

--- a/include/otf2xx/exception.hpp
+++ b/include/otf2xx/exception.hpp
@@ -72,7 +72,7 @@ inline exception make_exception(T_Args&&... args)
 }
 
 template <typename... T_Args>
-inline exception make_exception(OTF2_ErrorCode code, T_Args&&... args)
+inline exception make_otf2_exception(OTF2_ErrorCode code, T_Args&&... args)
 {
     return make_exception(OTF2_Error_GetName(code), ": ", OTF2_Error_GetDescription(code), "\n",
                           std::forward<T_Args>(args)...);
@@ -83,7 +83,7 @@ void inline check(OTF2_ErrorCode code, T_Args&&... args)
 {
     if (code != OTF2_SUCCESS)
     {
-        throw make_exception(code, std::forward<T_Args>(args)...);
+        throw make_otf2_exception(code, std::forward<T_Args>(args)...);
     }
 }
 

--- a/include/otf2xx/exception.hpp
+++ b/include/otf2xx/exception.hpp
@@ -60,23 +60,30 @@ namespace detail
         std::stringstream msg;
         using expander = int[];
         // Pre C++17 expansion
-        (void)expander{0, (void(msg << std::forward<T_Args>(args)), 0)...};
+        (void)expander{ 0, (void(msg << std::forward<T_Args>(args)), 0)... };
         return msg.str();
     }
 }
 
-template <typename... Args>
-inline void make_exception(Args&&... args)
+template <typename... T_Args>
+inline exception make_exception(T_Args&&... args)
 {
-    throw exception(detail::concat_args(std::forward<Args>(args)...));
+    return exception(detail::concat_args(std::forward<T_Args>(args)...));
 }
 
-template <typename... Args>
-void inline check(OTF2_ErrorCode code, Args&&... args)
+template <typename... T_Args>
+inline exception make_exception(OTF2_ErrorCode code, T_Args&&... args)
+{
+    return make_exception(OTF2_Error_GetName(code), ": ", OTF2_Error_GetDescription(code), "\n",
+                          std::forward<T_Args>(args)...);
+}
+
+template <typename... T_Args>
+void inline check(OTF2_ErrorCode code, T_Args&&... args)
 {
     if (code != OTF2_SUCCESS)
     {
-        make_exception(std::forward<Args>(args)...);
+        throw make_exception(code, std::forward<T_Args>(args)...);
     }
 }
 

--- a/include/otf2xx/exception.hpp
+++ b/include/otf2xx/exception.hpp
@@ -46,7 +46,7 @@ namespace otf2
 
 struct exception : std::runtime_error
 {
-    explicit exception(const std::string& arg) : std::runtime_error(arg)
+    explicit exception(std::string arg) : std::runtime_error(std::move(arg))
     {
     }
 };

--- a/include/otf2xx/reader/reader.hpp
+++ b/include/otf2xx/reader/reader.hpp
@@ -73,7 +73,7 @@ namespace reader
         reader(const std::string& name) : rdr(OTF2_Reader_Open(name.c_str())), callback_(nullptr)
         {
             if (rdr == nullptr)
-                make_exception("Couldn't open the trace file: ", name);
+                throw make_exception("Couldn't open the trace file: ", name);
         }
 
         /**

--- a/include/otf2xx/reference_generator.hpp
+++ b/include/otf2xx/reference_generator.hpp
@@ -104,7 +104,7 @@ public:
     {
         if (ref_type::undefined() == old_max + 1)
         {
-            make_exception("Cannot generate a new unused reference number");
+            throw make_exception("Cannot generate a new unused reference number");
         }
 
         return ++old_max;

--- a/include/otf2xx/writer/archive.hpp
+++ b/include/otf2xx/writer/archive.hpp
@@ -72,7 +72,7 @@ namespace writer
           serial(false), comm_(comm)
         {
             if (ar == nullptr)
-                make_exception("Couldn't open the archive '", name, "'");
+                throw make_exception("Couldn't open the archive '", name, "'");
 
             set_flush_callbacks();
             set_collective_callbacks();
@@ -92,7 +92,7 @@ namespace writer
           serial(true)
         {
             if (ar == nullptr)
-                make_exception("Couldn't open the archive '", name, "'");
+                throw make_exception("Couldn't open the archive '", name, "'");
 
             set_flush_callbacks();
             OTF2_Archive_SetSerialCollectiveCallbacks(ar);
@@ -419,7 +419,7 @@ namespace writer
             }
             else
             {
-                make_exception(
+                throw make_exception(
                     "Archive is in slave mode, so there can't be any global definition writer");
             }
 
@@ -461,7 +461,7 @@ namespace writer
     global& operator<<(archive& ar, Anything any)
     {
         if (!ar.is_master())
-            make_exception(
+            throw make_exception(
                 "Archive is in slave mode, so there can't be any global definition writer");
         return ar.get_global_writer() << any;
     }
@@ -469,7 +469,7 @@ namespace writer
     inline global& operator<<(archive& ar, const otf2::event::marker& evt)
     {
         if (!ar.is_master())
-            make_exception(
+            throw make_exception(
                 "Archive is in slave mode, so there can't be any global definition writer");
         return ar.get_global_writer() << evt;
     }
@@ -478,7 +478,7 @@ namespace writer
     global& operator<<(archive& ar, const otf2::definition::container<Definition>& c)
     {
         if (!ar.is_master())
-            make_exception(
+            throw make_exception(
                 "Archive is in slave mode, so there can't be any global definition writer");
 
         global& wrt = ar.get_global_writer();

--- a/include/otf2xx/writer/global.hpp
+++ b/include/otf2xx/writer/global.hpp
@@ -240,7 +240,7 @@ namespace writer
                 break;
 
             default:
-                make_exception("Unsupported scope type given");
+                throw make_exception("Unsupported scope type given");
             }
 
             check(OTF2_GlobalDefWriter_WriteMetricInstance(

--- a/include/otf2xx/writer/local.hpp
+++ b/include/otf2xx/writer/local.hpp
@@ -59,11 +59,11 @@ namespace writer
         {
             if (evt_wrt_ == nullptr)
             {
-                make_exception("Couldn't open local event writer for '", location, "'");
+                throw make_exception("Couldn't open local event writer for '", location, "'");
             }
             if (def_wrt_ == nullptr)
             {
-                make_exception("Couldn't open local definition writer for '", location, "'");
+                throw make_exception("Couldn't open local definition writer for '", location, "'");
             }
         }
 

--- a/src/reader/callback/definitions.cpp
+++ b/src/reader/callback/definitions.cpp
@@ -253,7 +253,7 @@ namespace reader
 
                     case OTF2_GROUP_TYPE_UNKNOWN:
                     default:
-                        make_exception("Unknown group type isn't supported");
+                        throw make_exception("Unknown group type isn't supported");
                         break;
                     }
 
@@ -355,7 +355,7 @@ namespace reader
                         break;
 
                     default:
-                        make_exception("Unknown scope type for metric instance given");
+                        throw make_exception("Unknown scope type for metric instance given");
                     }
 
                     reader->callback().definition(reader->metric_instances()[self]);


### PR DESCRIPTION
- `detail::make_exception` renamed to `concat_args` to reflect what it does (and used better implementation)
- `make_exception` returns an exception now (reflects the name and makes it easier to reason about)
- `check` now includes a description int the error message