### PR TITLE
Fix reference generator and add tests

### DIFF
--- a/include/otf2xx/definition/group.hpp
+++ b/include/otf2xx/definition/group.hpp
@@ -73,9 +73,8 @@ namespace definition
 
         using base::base;
 
-        using impl_type = typename base::impl_type;
-
     public:
+        using impl_type = typename base::impl_type;
         typedef typename impl_type::group_type group_type;
         typedef typename impl_type::group_flag_type group_flag_type;
         typedef typename impl_type::paradigm_type paradigm_type;

--- a/include/otf2xx/fwd.hpp
+++ b/include/otf2xx/fwd.hpp
@@ -38,9 +38,6 @@
 namespace otf2
 {
 
-template <typename T>
-class reference;
-
 template <typename Definition>
 class reference_generator;
 

--- a/include/otf2xx/reference.hpp
+++ b/include/otf2xx/reference.hpp
@@ -52,144 +52,143 @@
 namespace otf2
 {
 
+template <class T_Definition>
+struct reference_map;
+
 /**
  * @brief represents a reference number for definitions
  *
  * For each definition should be an own reference type, so the address space is seperated in a
  * typesafe manner.
  *
- * \tparam Type Used to seperate address spaces for different definitions
+ * \tparam T_Definition Definition this reference should refer to
  */
-template <typename Type>
-class reference
+template <class T_Definition>
+using reference = typename reference_map<T_Definition>::type;
+
+namespace detail
 {
-public:
     /**
-     * @brief ref_type the underlying type of refernce numbers
+     * @brief represents a reference number for definitions
      *
-     * Mostly uint64_t or uint32_t
-     */
-    typedef typename traits::reference_type<Type>::type ref_type;
-
-    reference() = delete;
-
-    /**
-     * @brief construct by value
-     * @param ref the number
-     */
-    reference(ref_type ref) : handle(ref)
-    {
-    }
-
-    /**
-     * @brief returns the reference number
-     * @return the reference number
-     */
-    ref_type get() const
-    {
-        return handle;
-    }
-
-    ~reference() = default;
-
-    /**
-     * @brief returns if the number equals to OTF2_UNDEFINED_UINT64
-     * @return true or false
-     */
-    bool is_undefined() const
-    {
-        return handle == undefined();
-    }
-
-    /**
-     * @brief operator ref_type
+     * For each definition should be an own reference type, so the address space is seperated in a
+     * typesafe manner.
      *
-     * implicitly convertible to ref_type
-     *
+     * \tparam Type Used to seperate address spaces for different definitions
      */
-    operator ref_type() const
+    template <typename Type>
+    class reference
     {
-        return handle;
-    }
+    public:
+        /**
+         * @brief ref_type the underlying type of refernce numbers
+         *
+         * Mostly uint64_t or uint32_t
+         */
+        typedef typename traits::reference_type<Type>::type ref_type;
 
-    /**
-     * @brief returns the undefined representing number
-     * @return OTF2_UNDEFINED_UINT64
-     */
-    template <typename as_type = ref_type>
-    static ref_type undefined()
-    {
-        return static_cast<as_type>(-1);
-    }
+        reference() = delete;
 
-protected:
-    ref_type handle;
+        /**
+         * @brief construct by value
+         * @param ref the number
+         */
+        reference(ref_type ref) : handle(ref)
+        {
+        }
+
+        /**
+         * @brief returns the reference number
+         * @return the reference number
+         */
+        ref_type get() const
+        {
+            return handle;
+        }
+
+        ~reference() = default;
+
+        /**
+         * @brief returns if the number equals to OTF2_UNDEFINED_UINT64
+         * @return true or false
+         */
+        bool is_undefined() const
+        {
+            return handle == undefined();
+        }
+
+        /**
+         * @brief operator ref_type
+         *
+         * implicitly convertible to ref_type
+         *
+         */
+        operator ref_type() const
+        {
+            return handle;
+        }
+
+        /**
+         * @brief returns the undefined representing number
+         * @return OTF2_UNDEFINED_UINT64
+         */
+        template <typename as_type = ref_type>
+        static ref_type undefined()
+        {
+            return static_cast<as_type>(-1);
+        }
+
+    protected:
+        ref_type handle;
+    };
+}
+
+template <class T_Definition>
+struct reference_map
+{
+    using type = detail::reference<T_Definition>;
 };
 
 template <typename T, otf2::common::group_type Type>
-class reference<definition::group<T, Type>> : public reference<definition::detail::group_base>
+struct reference_map<definition::group<T, Type>>
 {
-public:
-    reference(const reference<definition::detail::group_base>& base)
-    : reference<definition::detail::group_base>(base)
-    {
-    }
+    using type = detail::reference<definition::detail::group_base>;
 };
 
 template <>
-class reference<definition::metric_class> : public reference<definition::detail::metric_base>
+struct reference_map<definition::metric_class>
 {
-public:
-    reference(const reference<definition::detail::metric_base>& base)
-    : reference<definition::detail::metric_base>(base)
-    {
-    }
+    using type = detail::reference<definition::detail::metric_base>;
 };
 
 template <>
-class reference<definition::metric_instance> : public reference<definition::detail::metric_base>
+struct reference_map<definition::metric_instance>
 {
-public:
-    reference(const reference<definition::detail::metric_base>& base)
-    : reference<definition::detail::metric_base>(base)
-    {
-    }
+    using type = detail::reference<definition::detail::metric_base>;
 };
 
 template <>
-class reference<definition::io_directory> : public reference<definition::io_file>
+struct reference_map<definition::io_directory>
 {
-public:
-    reference(const reference<definition::io_file>& base) : reference<definition::io_file>(base)
-    {
-    }
+    using type = detail::reference<definition::io_file>;
 };
 
 template <>
-class reference<definition::io_regular_file> : public reference<definition::io_file>
+struct reference_map<definition::io_regular_file>
 {
-public:
-    reference(const reference<definition::io_file>& base) : reference<definition::io_file>(base)
-    {
-    }
+    using type = detail::reference<definition::io_file>;
 };
 
 template <typename T>
-class reference<definition::property<T>> : public reference<T>
+struct reference_map<definition::property<T>>
 {
-public:
-    reference(const reference<T>& base) : reference<T>(base)
-    {
-    }
+    using type = detail::reference<T>;
 };
 
 template <>
-class reference<definition::io_pre_created_handle_state> : public reference<definition::io_handle>
+struct reference_map<definition::io_pre_created_handle_state>
 {
-public:
-    reference(const reference<definition::io_handle>& base) : reference<definition::io_handle>(base)
-    {
-    }
+    using type = detail::reference<definition::io_handle>;
 };
 
 } // namespace otf2

--- a/include/otf2xx/reference.hpp
+++ b/include/otf2xx/reference.hpp
@@ -74,18 +74,22 @@ namespace detail
      * For each definition should be an own reference type, so the address space is seperated in a
      * typesafe manner.
      *
-     * \tparam Type Used to seperate address spaces for different definitions
+     * \tparam T_Tag Used to seperate address spaces for different definitions
      */
-    template <typename Type>
+    template <typename T_Tag>
     class reference
     {
     public:
         /**
-         * @brief ref_type the underlying type of refernce numbers
+         * @brief Tag type used for this reference number space
+         */
+        typedef T_Tag Tag;
+        /**
+         * @brief ref_type the underlying type of reference numbers
          *
          * Mostly uint64_t or uint32_t
          */
-        typedef typename traits::reference_type<Type>::type ref_type;
+        typedef typename traits::reference_type<Tag>::type ref_type;
 
         reference() = delete;
 

--- a/include/otf2xx/reference_generator.hpp
+++ b/include/otf2xx/reference_generator.hpp
@@ -78,11 +78,8 @@ public:
     template <typename Definition>
     void register_definition(const Definition& def)
     {
-        static_assert(
-            std::is_same<
-                otf2::reference<typename otf2::traits::reference_param_type<Definition>::type>,
-                RefType>::value,
-            "Trying to register a definition with a different id space");
+        static_assert(std::is_same<otf2::reference<Definition>, RefType>::value,
+                      "Trying to register a definition with a different id space");
 
         register_reference(def.ref());
     }
@@ -120,8 +117,7 @@ namespace detail
     class generate_ref
     {
     public:
-        otf2::reference<typename otf2::traits::reference_param_type<Definition>::type>
-        operator()(trace_reference_generator& gen);
+        otf2::reference<Definition> operator()(trace_reference_generator& gen);
     };
 } // namespace detail
 
@@ -241,10 +237,9 @@ public:
     }
 
     template <typename Definition>
-    otf2::reference<typename otf2::traits::reference_param_type<Definition>::type> next()
+    otf2::reference<Definition> next()
     {
-        return detail::generate_ref<typename traits::reference_param_type<Definition>::type>()(
-            *this);
+        return detail::generate_ref<Definition>()(*this);
     }
 
     reference_generator<otf2::reference<otf2::definition::location>> location_refs_;
@@ -272,135 +267,127 @@ public:
 namespace detail
 {
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::location>::type>
-    generate_ref<otf2::definition::location>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::location> generate_ref<otf2::definition::location>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.location_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::location_group>::type>
+    inline otf2::reference<otf2::definition::location_group>
     generate_ref<otf2::definition::location_group>::operator()(trace_reference_generator& gen)
     {
         return gen.location_group_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::system_tree_node>::type>
+    inline otf2::reference<otf2::definition::system_tree_node>
     generate_ref<otf2::definition::system_tree_node>::operator()(trace_reference_generator& gen)
     {
         return gen.system_tree_node_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::detail::group_base>::type>
+    inline otf2::reference<otf2::definition::detail::group_base>
     generate_ref<otf2::definition::detail::group_base>::operator()(trace_reference_generator& gen)
     {
         return gen.group_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::comm>::type>
-    generate_ref<otf2::definition::comm>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::comm> generate_ref<otf2::definition::comm>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.comm_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::region>::type>
-    generate_ref<otf2::definition::region>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::region> generate_ref<otf2::definition::region>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.region_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::attribute>::type>
-    generate_ref<otf2::definition::attribute>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::attribute> generate_ref<otf2::definition::attribute>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.attribute_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::parameter>::type>
-    generate_ref<otf2::definition::parameter>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::parameter> generate_ref<otf2::definition::parameter>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.parameter_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::string>::type>
-    generate_ref<otf2::definition::string>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::string> generate_ref<otf2::definition::string>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.string_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::source_code_location>::type>
+    inline otf2::reference<otf2::definition::source_code_location>
     generate_ref<otf2::definition::source_code_location>::operator()(trace_reference_generator& gen)
     {
         return gen.source_code_location_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::calling_context>::type>
+    inline otf2::reference<otf2::definition::calling_context>
     generate_ref<otf2::definition::calling_context>::operator()(trace_reference_generator& gen)
     {
         return gen.calling_context_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::interrupt_generator>::type>
+    inline otf2::reference<otf2::definition::interrupt_generator>
     generate_ref<otf2::definition::interrupt_generator>::operator()(trace_reference_generator& gen)
     {
         return gen.interrupt_generator_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::io_file>::type>
-    generate_ref<otf2::definition::io_file>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::io_file> generate_ref<otf2::definition::io_file>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.io_file_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::io_handle>::type>
-    generate_ref<otf2::definition::io_handle>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::io_handle> generate_ref<otf2::definition::io_handle>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.io_handle_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::io_paradigm>::type>
+    inline otf2::reference<otf2::definition::io_paradigm>
     generate_ref<otf2::definition::io_paradigm>::operator()(trace_reference_generator& gen)
     {
         return gen.io_paradigm_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::metric_member>::type>
+    inline otf2::reference<otf2::definition::metric_member>
     generate_ref<otf2::definition::metric_member>::operator()(trace_reference_generator& gen)
     {
         return gen.metric_member_refs_.next();
     }
 
     template <>
-    inline otf2::reference<
-        otf2::traits::reference_param_type<otf2::definition::detail::metric_base>::type>
+    inline otf2::reference<otf2::definition::detail::metric_base>
     generate_ref<otf2::definition::detail::metric_base>::operator()(trace_reference_generator& gen)
     {
         return gen.metric_refs_.next();
     }
 
     template <>
-    inline otf2::reference<otf2::traits::reference_param_type<otf2::definition::marker>::type>
-    generate_ref<otf2::definition::marker>::operator()(trace_reference_generator& gen)
+    inline otf2::reference<otf2::definition::marker> generate_ref<otf2::definition::marker>::
+    operator()(trace_reference_generator& gen)
     {
         return gen.marker_refs_.next();
     }

--- a/include/otf2xx/reference_generator.hpp
+++ b/include/otf2xx/reference_generator.hpp
@@ -239,7 +239,8 @@ public:
     template <typename Definition>
     otf2::reference<Definition> next()
     {
-        return detail::generate_ref<Definition>()(*this);
+        using Tag = typename otf2::reference<Definition>::Tag;
+        return detail::generate_ref<Tag>()(*this);
     }
 
     reference_generator<otf2::reference<otf2::definition::location>> location_refs_;

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -134,7 +134,7 @@ public:
     : attributes_(refs_), comms_(refs_), locations_(refs_), location_groups_(refs_),
       parameters_(refs_), regions_(refs_), strings_(refs_), system_tree_nodes_(refs_),
       source_code_locations_(refs_), calling_contexts_(refs_), interrupt_generators_(refs_),
-      io_handles_(refs_), io_files_(refs_), io_regular_files_(refs_), io_directories_(refs_),
+      io_handles_(refs_), io_regular_files_(refs_), io_directories_(refs_),
       io_paradigms_(refs_), io_pre_created_handle_states_(refs_), locations_groups_(refs_),
       regions_groups_(refs_),
       // metric_groups_(refs_),
@@ -350,11 +350,6 @@ public:
     void register_definition(const otf2::definition::io_handle& def)
     {
         io_handles_(def);
-    }
-
-    void register_definition(const otf2::definition::io_file& def)
-    {
-        io_files_(def);
     }
 
     void register_definition(const otf2::definition::io_regular_file& def)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ otf2xx_add_test(traits_test otf2xx::Core)
 
 otf2xx_add_test(intrusive_ptr_test otf2xx::Core)
 otf2xx_add_test(ref_gen_test otf2xx::Core)
+otf2xx_add_test(registry_test otf2xx::Core)
 
 otf2xx_add_test(writer_test otf2xx::Writer)
 add_test(NAME writer_test_cleanup COMMAND cmake -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/otf2xx_writer_trace)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ otf2xx_add_test(enums_test otf2xx::Core)
 otf2xx_add_test(traits_test otf2xx::Core)
 
 otf2xx_add_test(intrusive_ptr_test otf2xx::Core)
+otf2xx_add_test(ref_gen_test otf2xx::Core)
 
 otf2xx_add_test(writer_test otf2xx::Writer)
 add_test(NAME writer_test_cleanup COMMAND cmake -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/otf2xx_writer_trace)

--- a/tests/ref_gen_test.cpp
+++ b/tests/ref_gen_test.cpp
@@ -1,0 +1,88 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2018, Technische Universitaet Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <otf2xx/otf2.hpp>
+#include <otf2xx/reference_generator.hpp>
+#include <set>
+
+template <typename T>
+bool contains(const std::set<T>& container, const T& el)
+{
+    return container.find(el) != container.end();
+}
+
+TEST_CASE("test string reference generator")
+{
+    otf2::trace_reference_generator ref_gen;
+    otf2::definition::string s1{ 1, "Foo" };
+    using string_ref = otf2::reference<otf2::definition::string>;
+    std::set<string_ref> string_refs;
+    SECTION("Register with function")
+    {
+        ref_gen.register_definition(s1);
+        string_refs.insert(s1.ref());
+    }
+    SECTION("Register with functor")
+    {
+        ref_gen(s1);
+        string_refs.insert(s1.ref());
+        SECTION("Duplicate register should be allowed")
+        {
+            ref_gen(s1);
+        }
+    }
+    SECTION("Register multiple definitions")
+    {
+        // Use some with gaps
+        otf2::definition::string s2{ 2, "Foo" };
+        otf2::definition::string s3{ 4, "Foo" };
+        otf2::definition::string s4{ 10, "Foo" };
+        ref_gen(s2);
+        string_refs.insert(s2.ref());
+        ref_gen(s3);
+        string_refs.insert(s3.ref());
+        ref_gen(s4);
+        string_refs.insert(s4.ref());
+    }
+    // Check that the new couple of next() calls return unique refs (for every leaf section above)
+    for (int i = 0; i < 100; i++)
+    {
+        auto new_ref = ref_gen.next<otf2::definition::string>();
+        REQUIRE_FALSE(contains(string_refs, new_ref));
+        string_refs.insert(new_ref);
+    }
+}

--- a/tests/ref_gen_test.cpp
+++ b/tests/ref_gen_test.cpp
@@ -86,3 +86,55 @@ TEST_CASE("test string reference generator")
         string_refs.insert(new_ref);
     }
 }
+
+TEST_CASE("test io reference generator")
+{
+    otf2::trace_reference_generator ref_gen;
+    otf2::definition::string str{0, ""};
+    otf2::definition::system_tree_node sys_node{1, str, str};
+    otf2::definition::io_regular_file file{ 1, str, sys_node };
+    otf2::definition::io_directory dir{ 2, str, sys_node };
+    using ref = otf2::reference<otf2::definition::io_file>;
+    std::set<ref> refs;
+    SECTION("Directory ref must be unique after adding file ref")
+    {
+        ref_gen(file);
+        refs.insert(file.ref());
+        for (int i = 0; i < 100; i++)
+        {
+            auto new_ref = ref_gen.next<otf2::definition::io_directory>();
+            REQUIRE_FALSE(contains(refs, new_ref));
+            refs.insert(new_ref);
+        }
+    }
+    SECTION("File ref must be unique after adding directory ref")
+    {
+        ref_gen(dir);
+        refs.insert(dir.ref());
+        for (int i = 0; i < 100; i++)
+        {
+            auto new_ref = ref_gen.next<otf2::definition::io_regular_file>();
+            REQUIRE_FALSE(contains(refs, new_ref));
+            refs.insert(new_ref);
+        }
+    }
+    SECTION("All refs must be unqiue after adding both")
+    {
+        ref_gen(file);
+        refs.insert(file.ref());
+        ref_gen(dir);
+        refs.insert(dir.ref());
+        for (int i = 0; i < 100; i++)
+        {
+            auto new_ref = ref_gen.next<otf2::definition::io_file>();
+            REQUIRE_FALSE(contains(refs, new_ref));
+            refs.insert(new_ref);
+            new_ref = ref_gen.next<otf2::definition::io_regular_file>();
+            REQUIRE_FALSE(contains(refs, new_ref));
+            refs.insert(new_ref);
+            new_ref = ref_gen.next<otf2::definition::io_directory>();
+            REQUIRE_FALSE(contains(refs, new_ref));
+            refs.insert(new_ref);
+        }
+    }
+}

--- a/tests/registry_test.cpp
+++ b/tests/registry_test.cpp
@@ -1,0 +1,89 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2018, Technische Universitaet Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <otf2xx/otf2.hpp>
+#include <otf2xx/registry.hpp>
+#include <set>
+
+template <typename T>
+bool contains(const std::set<T>& container, const T& el)
+{
+    return container.find(el) != container.end();
+}
+
+TEST_CASE("Add and get strings")
+{
+    otf2::Registry reg;
+    SECTION("Use predefined id")
+    {
+        const std::string value = "The answer.";
+        SECTION("Add existing string")
+        {
+            otf2::definition::string str(42, value);
+            reg.register_definition(str);
+            REQUIRE(str == reg.strings()[42]);
+        }
+        SECTION("Create with id")
+        {
+            auto str = reg.strings().create(42, value);
+            REQUIRE(str.str() == value);
+            REQUIRE(str.ref() == 42);
+            REQUIRE(str == reg.strings()[42]);
+        }
+        auto str = reg.strings()[42];
+        REQUIRE(str.str() == value);
+        REQUIRE(str.ref() == 42);
+    }
+    SECTION("Use auto-generated id")
+    {
+        std::set<otf2::reference<otf2::definition::string>> refs;
+        SECTION("With manually added string")
+        {
+            refs.insert(reg.strings().create(42, "foo").ref());
+        }
+        SECTION("Without manually added string")
+        {
+            // Nothing to do
+        }
+        for (int i = 0; i < int(1e5); i++)
+        {
+            auto str = reg.strings().create("Value" + std::to_string(i));
+            REQUIRE(!contains(refs, str.ref()));
+            refs.insert(str.ref());
+        }
+    }
+}


### PR DESCRIPTION
PR #30 broke the reference generator by removing the required trait.

This adds a test, that shows this and fixes the problem. All changes are almost transparent in the interface (exception: No fwd declaration of `otf2::reference<T>` but that is rarely required)

Changes:

- Remove references to `reference_param_type` trait
- Move `otf2:: reference` into detail namespace
- Establish a mapping of definitions to references which defaults to `otf2::detail:.reference<T_Def>`
- Specialize this where required (same ID spaces)
- Add using-template `otf2::reference` which now can be used as before but resolves to the unique reference type. This makes sure, that all references to the same id space are the same type (static_assert in e.g. ref-gen check this, and it affects other specializations)
- Add `otf2::detail::reference::Tag` to query the tag type used (required for choosing a specialization)