### PR TITLE
Use TMP to simplify code

### DIFF
--- a/include/otf2xx/tmp.hpp
+++ b/include/otf2xx/tmp.hpp
@@ -1,0 +1,43 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_TMP_HPP
+#define INCLUDE_OTF2XX_TMP_HPP
+
+#include <otf2xx/tmp/algorithm.hpp>
+#include <otf2xx/tmp/runtime.hpp>
+#include <otf2xx/tmp/typelist.hpp>
+
+#endif // INCLUDE_OTF2XX_TMP_HPP
+

--- a/include/otf2xx/tmp/algorithm.hpp
+++ b/include/otf2xx/tmp/algorithm.hpp
@@ -1,0 +1,179 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_TMP_ALGORITHM_HPP
+#define INCLUDE_OTF2XX_TMP_ALGORITHM_HPP
+
+#include <otf2xx/tmp/typelist.hpp>
+#include <type_traits>
+
+namespace otf2
+{
+namespace tmp
+{
+    /**
+     * Note: All template parameters TList take only typelists
+     *       All others take any variadic sequence type (e.g. std::tuple)
+     */
+
+    /** @brief Standard void_t implementation to support e.g. detection idiom */
+    template <class...>
+    using void_t = void;
+
+    /** @brief Return true, when the type ToSearch is contained in the sequence */
+    template <class Seq, typename ToSearch>
+    struct contains;
+
+    /** @brief Return the size (number of arguments) of a sequence */
+    template <class Seq>
+    struct size;
+
+    /** @brief Concatenate multiple typelists into one */
+    template <typename... TLists>
+    struct concat;
+    template <typename... TLists>
+    using concat_t = typename concat<TLists...>::type;
+
+    /**
+     * @brief Apply all elements from Seq to TargetSeq:
+     * Seq<Foo, Bar> -> TargetSeq<Foo, Bar>
+     */
+    template <class Seq, template <typename...> class TargetSeq>
+    struct apply;
+    template <class Seq, template <typename...> class TargetSeq>
+    using apply_t = typename apply<Seq, TargetSeq>::type;
+
+    /**
+     * @brief Apply the functor F to every element of TList:
+     * typelist<a1, a2,...> -> typelist<F<a1>::type, F<a2>::type, ...>
+     */
+    template <class TList, template <typename> class F>
+    struct transform;
+    template <class TList, template <typename> class F>
+    using transform_t = typename transform<TList, F>::type;
+
+    /** @brief Remove all elements from TList not matching the predicate Cond */
+    template <class TList, template <typename...> class Cond>
+    struct filter;
+    template <class TList, template <typename...> class Cond>
+    using filter_t = typename filter<TList, Cond>::type;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ///////////////////////////////////////////////////////////////////////////
+
+    namespace detail
+    {
+        /** @brief A list of bools */
+        template <bool...>
+        struct bool_list;
+
+        /** @brief Return true, when all values are true */
+        template <bool... bools>
+        using all = std::is_same<bool_list<true, bools...>, bool_list<bools..., true>>;
+
+        /** @brief Return true, when any value is true */
+        template <bool... bools>
+        using any = std::integral_constant<bool, !all<(!bools)...>::value>;
+    }
+
+    template <typename ToSearch, template <typename...> class Seq, typename... Ts>
+    struct contains<Seq<Ts...>, ToSearch> : detail::any<std::is_same<Ts, ToSearch>::value...>
+    {
+    };
+
+    template <template <typename...> class Seq, typename... Ts>
+    struct size<Seq<Ts...>> : std::integral_constant<std::size_t, sizeof...(Ts)>
+    {
+    };
+
+    template <>
+    struct concat<>
+    {
+        using type = typelist<>;
+    };
+
+    template <typename... Args1>
+    struct concat<typelist<Args1...>>
+    {
+        using type = typelist<Args1...>;
+    };
+
+    template <typename... Args1, typename... Args2, typename... Seqs>
+    struct concat<typelist<Args1...>, typelist<Args2...>, Seqs...>
+    : concat<typelist<Args1..., Args2...>, Seqs...>
+    {
+    };
+
+    template <template <typename...> class Seq, template <typename...> class TargetSeq,
+              typename... Ts>
+    struct apply<Seq<Ts...>, TargetSeq>
+    {
+        using type = TargetSeq<Ts...>;
+    };
+
+    template <template <typename> class F, typename... Ts>
+    struct transform<typelist<Ts...>, F>
+    {
+        using type = typelist<typename F<Ts>::type...>;
+    };
+
+    namespace detail
+    {
+        template <bool>
+        struct return_if
+        {
+            template <typename T>
+            using type = typelist<T>;
+        };
+        template <>
+        struct return_if<false>
+        {
+            template <typename T>
+            using type = typelist<>;
+        };
+    }
+
+    template <template <typename...> class Cond, typename... Ts>
+    struct filter<typelist<Ts...>, Cond>
+    {
+        // Convert each element T into either typelist<T> or typelist<> depending on Cond
+        // Then concatenate all of those
+        using type = concat_t<typename detail::return_if<Cond<Ts>::value>::template type<Ts>...>;
+    };
+
+} // namespace tmp
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_TMP_ALGORITHM_HPP

--- a/include/otf2xx/tmp/runtime.hpp
+++ b/include/otf2xx/tmp/runtime.hpp
@@ -1,0 +1,97 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_TMP_RUNTIME_HPP
+#define INCLUDE_OTF2XX_TMP_RUNTIME_HPP
+
+#include <type_traits>
+#include <utility>
+
+namespace otf2
+{
+namespace tmp
+{
+    /**
+     * @brief Call the given functor for every element in the sequence
+     * There must be an appropriate get<Index>(seq) function available via ADL
+     */
+    template <class Seq, typename F>
+    void foreach (Seq&& seq, F && f);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ///////////////////////////////////////////////////////////////////////////
+
+    namespace detail
+    {
+        // Dummy as placeholder
+        template <std::size_t idx, class T>
+        void get(T&&);
+
+        template <class Seq>
+        struct foreach;
+
+        template <template <typename...> class Seq, typename... Ts>
+        struct foreach<Seq<Ts...>>
+        {
+            using indices = std::make_index_sequence<sizeof...(Ts)>;
+
+            // Template required to enable ADL at instantiation point
+            template <class ActSeq, class F, std::size_t... Idx>
+            static void do_apply(ActSeq&& seq, F&& f, std::index_sequence<Idx...>)
+            {
+                // Pre C++17 expansion of `f(get<Idx>(std::forward<ActSeq>(seq))`
+                // https://stackoverflow.com/questions/25680461/variadic-template-pack-expansion/25683817#25683817
+                using expander = int[];
+                (void)expander{ 0, ((void)f(get<Idx>(std::forward<ActSeq>(seq))), 0)... };
+            }
+            template <class ActSeq, class F>
+            static void apply(ActSeq&& seq, F&& f)
+            {
+                do_apply(std::forward<ActSeq>(seq), std::forward<F>(f), indices{});
+            }
+        };
+    }
+
+    template <class Seq, typename F>
+    void foreach (Seq&& seq, F && f)
+    {
+        using clean_seq = std::remove_reference_t<Seq>;
+        detail::foreach<clean_seq>::apply(std::forward<Seq>(seq), std::forward<F>(f));
+    }
+
+} // namespace tmp
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_TMP_RUNTIME_HPP

--- a/include/otf2xx/tmp/typelist.hpp
+++ b/include/otf2xx/tmp/typelist.hpp
@@ -1,0 +1,57 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_TMP_TYPELIST_HPP
+#define INCLUDE_OTF2XX_TMP_TYPELIST_HPP
+
+#include <type_traits>
+
+namespace otf2
+{
+namespace tmp
+{
+    /**
+     * @brief A list of types
+     * This is used for all template metaprogramming algorithms.
+     * To convert any variadic template into a typelist use apply_t<MyList, typelist>
+     */
+    template <typename... Ts>
+    struct typelist
+    {
+    };
+
+} // namespace tmp
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_TMP_TYPELIST_HPP

--- a/include/otf2xx/traits/definition.hpp
+++ b/include/otf2xx/traits/definition.hpp
@@ -36,26 +36,37 @@
 #define INCLUDE_OTF2XX_TRAITS_DEFINITION_HPP
 
 #include <otf2xx/definition/pre_fwd.hpp>
-#include <otf2xx/traits/traits.hpp>
+#include <otf2xx/tmp/algorithm.hpp>
+#include <otf2xx/tmp/typelist.hpp>
 #include <type_traits>
 
 namespace otf2
 {
 namespace traits
 {
+    /// All definitions that can be referred to and have a unique id space (Tag of reference<>)
+    using referable_definitions_base = tmp::typelist<
+        otf2::definition::attribute, otf2::definition::comm, otf2::definition::detail::group_base,
+        otf2::definition::location, otf2::definition::location_group, otf2::definition::parameter,
+        otf2::definition::region, otf2::definition::string, otf2::definition::system_tree_node,
+        otf2::definition::detail::metric_base, otf2::definition::metric_member,
+        otf2::definition::source_code_location, otf2::definition::calling_context,
+        otf2::definition::interrupt_generator, otf2::definition::marker, otf2::definition::io_file,
+        otf2::definition::io_handle, otf2::definition::io_paradigm>;
+    /// Definitions that can be referred to but don't have a unique id space
+    /// They will use an id from the space of one of the types in @ref referable_definitions_base
+    using referable_definitions_ext =
+        tmp::typelist<otf2::definition::metric_class, otf2::definition::metric_instance,
+                      otf2::definition::io_regular_file, otf2::definition::io_directory>;
+    /// Definitions without a reference
+    using unreferable_definitions = tmp::typelist<otf2::definition::mapping_table,
+                                                  otf2::definition::io_pre_created_handle_state>;
+
+    using all_definitions = tmp::concat_t<referable_definitions_base, referable_definitions_ext,
+                                          unreferable_definitions>;
 
     template <typename Type>
-    struct is_definition : std::false_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::attribute> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::comm> : std::true_type
+    struct is_definition : tmp::contains<all_definitions, Type>
     {
     };
 
@@ -64,110 +75,11 @@ namespace traits
     {
     };
 
-    template <>
-    struct is_definition<otf2::definition::location> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::location_group> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::parameter> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::region> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::string> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::system_tree_node> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::metric_class> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::metric_instance> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::metric_member> : std::true_type
-    {
-    };
-
     template <typename Definition>
     struct is_definition<otf2::definition::property<Definition>> : std::true_type
     {
     };
 
-    template <>
-    struct is_definition<otf2::definition::source_code_location> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::calling_context> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::interrupt_generator> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::mapping_table> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::marker> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_file> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_regular_file> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_directory> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_handle> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_paradigm> : std::true_type
-    {
-    };
-
-    template <>
-    struct is_definition<otf2::definition::io_pre_created_handle_state> : std::true_type
-    {
-    };
 } // namespace traits
 } // namespace otf2
 

--- a/include/otf2xx/traits/reference_tag.hpp
+++ b/include/otf2xx/traits/reference_tag.hpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef INCLUDE_OTF2XX_TRAITS_REFERENCE_TAG_HPP
+#define INCLUDE_OTF2XX_TRAITS_REFERENCE_TAG_HPP
+
+#include <otf2xx/reference.hpp>
+
+namespace otf2
+{
+namespace traits
+{
+    /** @brief Get the tag type used for the id space of a definition */
+    template <typename Definition>
+    struct reference_tag
+    {
+        using type = typename ::otf2::reference<Definition>::tag_type;
+    };
+    template <typename Definition>
+    using reference_tag_t = typename reference_tag<Definition>::type;
+
+} // namespace traits
+} // namespace otf2
+
+#endif // INCLUDE_OTF2XX_TRAITS_REFERENCE_TAG_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,8 @@ if(NOT OTF2XX_ENABLE_ALL_TESTS)
     return()
 endif()
 
+otf2xx_add_test(tmp_test otf2xx::Core)
+
 otf2xx_add_test(intrusive_ptr_test otf2xx::Core)
 otf2xx_add_test(ref_gen_test otf2xx::Core)
 otf2xx_add_test(registry_test otf2xx::Core)

--- a/tests/tmp_test.cpp
+++ b/tests/tmp_test.cpp
@@ -1,0 +1,183 @@
+/*
+ * This file is part of otf2xx (https://github.com/tud-zih-energy/otf2xx)
+ * otf2xx - A wrapper for the Open Trace Format 2 library
+ *
+ * Copyright (c) 2013-2016, Technische Universität Dresden, Germany
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <otf2xx/tmp.hpp>
+#include <tuple>
+#include <type_traits>
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+namespace tmp = otf2::tmp;
+
+/**
+ * Required because we get something like (std::true_type) (with parens)
+ * on which we cannot do (std::true_type)::value
+ * Instead we (pretend) to call a function with a function pointer taking our type as an argument
+ * and return our argument which can then be queried by decltype
+ */
+template <typename Pred>
+Pred get_type(void (*)(Pred));
+// Make it less ugly
+#define TMP_GET_TYPE(PRED) decltype(get_type((void(*) PRED)0))
+static_assert(std::is_same<TMP_GET_TYPE((int)), int>::value, "get_type is wrong");
+static_assert(!std::is_same<TMP_GET_TYPE((int)), float>::value, "get_type is wrong");
+
+// Note: All asserts require double-parens: TMP_ASSERT((mycheck))
+// Shorter static assert for any predicate having a ::value member. Requires true
+#define TMP_ASSERT(PRED) static_assert(TMP_GET_TYPE(PRED)::value, #PRED)
+// Shorter static assert for any predicate having a ::value member. Requires false
+#define TMP_ASSERT_NOT(PRED) static_assert(!TMP_GET_TYPE(PRED)::value, #PRED)
+// Assert the the passed types are the same
+#define TMP_ASSERT_SAME(LHS, RHS)                                                                  \
+    static_assert(std::is_same<TMP_GET_TYPE(LHS), TMP_GET_TYPE(RHS)>::value, #LHS "!=" #RHS)
+
+using list1 = tmp::typelist<int, double>;
+using list2 = tmp::typelist<float>;
+using list3 = tmp::typelist<double>;
+using list4 = tmp::typelist<float, double, double>;
+using list5 = tmp::typelist<double, float, double>;
+using list6 = tmp::typelist<double, double, float>;
+using empty = tmp::typelist<>;
+
+TMP_ASSERT_SAME((tmp::concat_t<list1, empty>), (list1));
+TMP_ASSERT_SAME((tmp::concat_t<list1, list1>), (tmp::typelist<int, double, int, double>));
+TMP_ASSERT_SAME((tmp::concat_t<list1, list3>), (tmp::typelist<int, double, double>));
+TMP_ASSERT_SAME((tmp::concat_t<list1, list2>), (tmp::typelist<int, double, float>));
+TMP_ASSERT_SAME((tmp::concat_t<list1, list3>), (tmp::typelist<int, double, double>));
+
+TMP_ASSERT((tmp::contains<list1, int>));
+TMP_ASSERT((tmp::contains<list1, double>));
+TMP_ASSERT_NOT((tmp::contains<list1, float>));
+TMP_ASSERT_NOT((tmp::contains<list2, int>));
+TMP_ASSERT((tmp::contains<list2, float>));
+TMP_ASSERT_NOT((tmp::contains<empty, int>));
+
+TMP_ASSERT_SAME((tmp::apply_t<list1, std::tuple>), (std::tuple<int, double>));
+TMP_ASSERT_SAME((tmp::apply_t<list2, std::tuple>), (std::tuple<float>));
+TMP_ASSERT_SAME((tmp::apply_t<empty, std::tuple>), (std::tuple<>));
+
+template <typename T>
+struct make_not_double
+{
+    using type = T;
+};
+template <>
+struct make_not_double<double>
+{
+    using type = float;
+};
+
+TMP_ASSERT_SAME((tmp::transform_t<list1, make_not_double>), (tmp::typelist<int, float>));
+TMP_ASSERT_SAME((tmp::transform_t<list2, make_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::transform_t<list3, make_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::transform_t<empty, make_not_double>), (tmp::typelist<>));
+
+template <typename T>
+struct is_not_double : std::true_type
+{
+};
+template <>
+struct is_not_double<double> : std::false_type
+{
+};
+
+template <typename T, typename = void>
+struct sfinae_user : std::false_type
+{
+};
+template <typename T>
+struct sfinae_user<T, tmp::void_t<typename T::type>> : std::true_type
+{
+};
+
+TMP_ASSERT_SAME((tmp::filter_t<list1, is_not_double>), (tmp::typelist<int>));
+TMP_ASSERT_SAME((tmp::filter_t<list2, is_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::filter_t<list3, is_not_double>), (tmp::typelist<>));
+TMP_ASSERT_SAME((tmp::filter_t<list4, is_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::filter_t<list5, is_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::filter_t<list6, is_not_double>), (tmp::typelist<float>));
+TMP_ASSERT_SAME((tmp::filter_t<empty, is_not_double>), (tmp::typelist<>));
+// Common filters might use sfinae/detection idiom. Make sure we support this directly
+TMP_ASSERT_SAME((tmp::filter_t<tmp::typelist<std::true_type, float, std::false_type>, sfinae_user>),
+                (tmp::typelist<std::true_type, std::false_type>));
+
+struct print_type
+{
+    std::string txt;
+    void operator()(int)
+    {
+        txt += "int,";
+    }
+    void operator()(unsigned)
+    {
+        txt += "unsigned,";
+    }
+    template <typename T>
+    void operator()(T)
+    {
+        txt += "T,";
+    }
+};
+
+TEST_CASE("foreach", "[tmp]")
+{
+    std::tuple<int, unsigned, int, float> values{ 1, 1, 1, 1 };
+
+    print_type visitor;
+    SECTION("Visit full sequence")
+    {
+        tmp::foreach (values, visitor);
+        REQUIRE(visitor.txt == "int,unsigned,int,T,");
+    }
+
+    SECTION("Visit single sequence")
+    {
+        tmp::foreach (std::make_tuple(1), visitor);
+        REQUIRE(visitor.txt == "int,");
+    }
+
+    SECTION("Visit empty sequence")
+    {
+        tmp::foreach (std::tuple<>{}, visitor);
+        REQUIRE(visitor.txt == "");
+    }
+
+    SECTION("Modify sequence")
+    {
+        tmp::foreach (values, [](auto& val) { ++val; });
+        decltype(values) expected{ 2, 2, 2, 2 };
+        REQUIRE(values == expected);
+    }
+}


### PR DESCRIPTION
Based on #32. This shows the strengths of the approach added there: Using a unique `reference<>` type per ID namespace
  - With this it was discovered, that `io_pre_created_handle_state` had its own references which is wrong. This was fixed.

New:
  - Add basic TMP (template meta programming): concat, contains, apply, transform
  - Test those
  - Add lists `referable_definitions_base`, `referable_definitions_ext`, `unreferable_definitions` and sort definitions into those (not including templated ones)
  - Use this to automatically construct a tuple of reference generators for all base definitions (id spaces) which removes 90% of the code in `reference_generator.hpp`

The same can be used for the registry to get rid of all the duplicate code there.

Note how this also provides meaningful meta data on definitions that can be used further. E.g. it should be impossible to create a `reference<>` of a type not in `referable_definitions_base`.
Note also, how it makes adding a new definition as easy as adding it to a list. Previously it required changing code in multiple locations which can easily be forgotten. (3x in reference_generator.hpp, ~5 in registry.hpp)