### PR TITLE
non-const registry.get()

### DIFF
--- a/include/otf2xx/definition/container.hpp
+++ b/include/otf2xx/definition/container.hpp
@@ -133,6 +133,14 @@ namespace definition
             return data.at(key);
         }
 
+        value_type& operator[](key_type key)
+        {
+            if (key == otf2::reference<Definition>::undefined())
+                return undefined_;
+
+            return data.at(key);
+        }
+
         template <typename... Args>
         value_type& emplace(key_type ref, Args&&... args)
         {

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -199,6 +199,12 @@ public:
     }
 
     template <typename Key>
+    std::enable_if_t<has_type<Key, key_list>::value, Definition&> operator[](Key key)
+    {
+        return std::get<Index<Key, key_list>::value>(lookup_maps_).at(key.key);
+    }
+
+    template <typename Key>
     std::enable_if_t<has_type<Key, key_list>::value> operator()(Key key, const Definition& def)
     {
         assert(def.ref() != Definition::reference_type::undefined());

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -66,6 +66,11 @@ public:
         return definitions_[ref];
     }
 
+    Definition& operator[](typename Definition::reference_type ref)
+    {
+        return definitions_[ref];
+    }
+
     void operator()(const Definition& def)
     {
         assert(def.ref() != Definition::reference_type::undefined());


### PR DESCRIPTION
This adds the needed non-const functions missing for non-const `registry.get()` to work 