### PR TITLE
Non const find in registry

### DIFF
--- a/include/otf2xx/definition/container.hpp
+++ b/include/otf2xx/definition/container.hpp
@@ -70,7 +70,7 @@ namespace definition
         class iterator
         {
         public:
-            iterator(typename map_type::const_iterator it, typename map_type::const_iterator end)
+            iterator(typename map_type::iterator it, typename map_type::iterator end)
             : it(it), end(end)
             {
             }
@@ -90,14 +90,14 @@ namespace definition
                 return iterator(it++, end);
             }
 
-            const value_type& operator*() const
+            value_type& operator*()
             {
                 assert(it != end);
 
                 return it->second;
             }
 
-            const value_type* operator->() const
+            value_type* operator->()
             {
                 assert(it != end);
 
@@ -120,10 +120,66 @@ namespace definition
             }
 
         private:
+            typename map_type::iterator it;
+            typename map_type::iterator end;
+        };
+        class const_iterator
+        {
+        public:
+            const_iterator(typename map_type::const_iterator it,
+                           typename map_type::const_iterator end)
+            : it(it), end(end)
+            {
+            }
+
+            const_iterator& operator++()
+            {
+                assert(it != end);
+
+                ++it;
+                return *this;
+            }
+
+            const_iterator operator++(int) // postfix ++
+            {
+                assert(it != end);
+
+                return const_iterator(it++, end);
+            }
+
+            const value_type& operator*() const
+            {
+                assert(it != end);
+
+                return it->second;
+            }
+
+            const value_type* operator->() const
+            {
+                assert(it != end);
+
+                return &(it->second);
+            }
+
+            bool operator==(const const_iterator& other) const
+            {
+                return it == other.it;
+            }
+
+            bool operator!=(const const_iterator& other) const
+            {
+                return !(*this == other);
+            }
+
+            explicit operator bool() const
+            {
+                return it != end;
+            }
+
+        private:
             typename map_type::const_iterator it;
             typename map_type::const_iterator end;
         };
-        typedef iterator const_iterator;
 
         const value_type& operator[](key_type key) const
         {
@@ -166,19 +222,33 @@ namespace definition
             return data.size();
         }
 
-        const_iterator find(key_type key) const
+        iterator find(key_type key)
         {
             return iterator(data.find(key), data.end());
         }
 
-        const_iterator begin() const
+        iterator begin()
         {
             return iterator(data.begin(), data.end());
         }
 
-        const_iterator end() const
+        iterator end()
         {
             return iterator(data.end(), data.end());
+        }
+        const_iterator find(key_type key) const
+        {
+            return const_iterator(data.find(key), data.end());
+        }
+
+        const_iterator begin() const
+        {
+            return const_iterator(data.begin(), data.end());
+        }
+
+        const_iterator end() const
+        {
+            return const_iterator(data.end(), data.end());
         }
 
     private:

--- a/include/otf2xx/definition/container.hpp
+++ b/include/otf2xx/definition/container.hpp
@@ -67,15 +67,20 @@ namespace definition
         typedef std::map<key_type, value_type> map_type;
 
     public:
-        class iterator
+        template <bool IsMutable>
+        class base_iterator
         {
         public:
-            iterator(typename map_type::iterator it, typename map_type::iterator end)
-            : it(it), end(end)
+            using map_iterator = typename std::conditional<IsMutable, typename map_type::iterator,
+                                                           typename map_type::const_iterator>::type;
+            using it_value_type =
+                typename std::conditional<IsMutable, value_type, const value_type>::type;
+
+            base_iterator(map_iterator it, map_iterator end) : it(it), end(end)
             {
             }
 
-            iterator& operator++()
+            base_iterator& operator++()
             {
                 assert(it != end);
 
@@ -83,33 +88,33 @@ namespace definition
                 return *this;
             }
 
-            iterator operator++(int) // postfix ++
+            base_iterator operator++(int) // postfix ++
             {
                 assert(it != end);
 
                 return iterator(it++, end);
             }
 
-            value_type& operator*()
+            it_value_type& operator*()
             {
                 assert(it != end);
 
                 return it->second;
             }
 
-            value_type* operator->()
+            it_value_type* operator->()
             {
                 assert(it != end);
 
                 return &(it->second);
             }
 
-            bool operator==(const iterator& other) const
+            bool operator==(const base_iterator& other) const
             {
                 return it == other.it;
             }
 
-            bool operator!=(const iterator& other) const
+            bool operator!=(const base_iterator& other) const
             {
                 return !(*this == other);
             }
@@ -120,66 +125,12 @@ namespace definition
             }
 
         private:
-            typename map_type::iterator it;
-            typename map_type::iterator end;
+            map_iterator it;
+            map_iterator end;
         };
-        class const_iterator
-        {
-        public:
-            const_iterator(typename map_type::const_iterator it,
-                           typename map_type::const_iterator end)
-            : it(it), end(end)
-            {
-            }
 
-            const_iterator& operator++()
-            {
-                assert(it != end);
-
-                ++it;
-                return *this;
-            }
-
-            const_iterator operator++(int) // postfix ++
-            {
-                assert(it != end);
-
-                return const_iterator(it++, end);
-            }
-
-            const value_type& operator*() const
-            {
-                assert(it != end);
-
-                return it->second;
-            }
-
-            const value_type* operator->() const
-            {
-                assert(it != end);
-
-                return &(it->second);
-            }
-
-            bool operator==(const const_iterator& other) const
-            {
-                return it == other.it;
-            }
-
-            bool operator!=(const const_iterator& other) const
-            {
-                return !(*this == other);
-            }
-
-            explicit operator bool() const
-            {
-                return it != end;
-            }
-
-        private:
-            typename map_type::const_iterator it;
-            typename map_type::const_iterator end;
-        };
+        using iterator = base_iterator<true>;
+        using const_iterator = base_iterator<false>;
 
         const value_type& operator[](key_type key) const
         {

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -277,7 +277,8 @@ public:
     {
         const auto& definitions = std::get<Index<Key, key_list>::value>(lookup_maps_);
         auto it = definitions.find(key.key);
-        return it != definitions.end() ? *it : (*this)[otf2::reference<Definition>::undefined()];
+        return it != definitions.end() ? it->second :
+                                         (*this)[otf2::reference<Definition>::undefined()];
     }
 
     template <typename Key>
@@ -285,7 +286,8 @@ public:
     {
         auto& definitions = std::get<Index<Key, key_list>::value>(lookup_maps_);
         auto it = definitions.find(key.key);
-        return it != definitions.end() ? *it : (*this)[otf2::reference<Definition>::undefined()];
+        return it != definitions.end() ? it->second :
+                                         (*this)[otf2::reference<Definition>::undefined()];
     }
 
 private:

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -116,6 +116,12 @@ public:
         return definitions_.count(ref) > 0;
     }
 
+    Definition& find(typename Definition::reference_type ref)
+    {
+        auto it = definitions_.find(ref);
+        return it != definitions_.end() ? *it : definitions_[ref.undefined()];
+    }
+
     const Definition& find(typename Definition::reference_type ref) const
     {
         auto it = definitions_.find(ref);
@@ -274,6 +280,14 @@ public:
         return it != definitions.end() ? *it : (*this)[otf2::reference<Definition>::undefined()];
     }
 
+    template <typename Key>
+    std::enable_if_t<has_type<Key, key_list>::value, Definition&> find(Key key)
+    {
+        auto& definitions = std::get<Index<Key, key_list>::value>(lookup_maps_);
+        auto it = definitions.find(key.key);
+        return it != definitions.end() ? *it : (*this)[otf2::reference<Definition>::undefined()];
+    }
+
 private:
     std::tuple<std::map<typename KeyList::key_type, Definition>...> lookup_maps_;
 };
@@ -422,6 +436,11 @@ public:
         return get_holder<Definition>().has(key);
     }
 
+    template <typename Definition, typename Key>
+    auto& find(const Key& key)
+    {
+        return get_holder<Definition>().find(key);
+    }
     template <typename Definition, typename Key>
     const auto& find(const Key& key) const
     {

--- a/include/otf2xx/writer/archive.hpp
+++ b/include/otf2xx/writer/archive.hpp
@@ -382,7 +382,7 @@ namespace writer
             post_flush_callback_ = f;
         }
 
-        otf2::registry& registry()
+        Registry& registry()
         {
             return get_global_writer().registry();
         }


### PR DESCRIPTION
This adds a non-const variant for the last remaining member-access function of the registry.

I'm personally not happy with the amount of code-copying between the normal `iterator` and the `const_iterator` but my google-fu did not find a satisfying way of unifying both those. If any of you find a more satisfying way to unify them I would be happy to implement it