### PR TITLE
Add emplace() to registry

### DIFF
--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -220,6 +220,15 @@ public:
         this->refs_.register_definition(def);
     }
 
+    template <typename Key, typename... Args>
+    std::enable_if_t<has_type<Key, key_list>::value,
+                     std::pair<typename std::map<Key, Definition>::iterator, bool>>
+    emplace(Args&&... args)
+    {
+        return std::get<Index<Key, key_list>::value>(lookup_maps_)
+            .emplace(std::forward<Args>(args)...);
+    }
+
     template <typename Key>
     std::enable_if_t<has_type<Key, key_list>::value>
     operator()(Key key, otf2::definition::detail::weak_ref<Definition> ref)
@@ -424,6 +433,12 @@ public:
     const auto& get(const Key& key) const
     {
         return get_holder<Definition>()[key];
+    }
+
+    template <typename Definition, typename... Args>
+    auto emplace(Args&&... args)
+    {
+        return get_holder<Definition>().emplace(std::forward<Args>(args)...);
     }
 
     template <typename Definition, typename Key>

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -222,7 +222,7 @@ public:
 
     template <typename Key, typename... Args>
     std::enable_if_t<has_type<Key, key_list>::value,
-                     std::pair<typename std::map<Key::key_type, Definition>::iterator, bool>>
+                     std::pair<typename std::map<typename Key::key_type, Definition>::iterator, bool>>
     emplace(Key key, Args&&... args)
     {
         return std::get<Index<Key, key_list>::value>(lookup_maps_)

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -223,10 +223,10 @@ public:
     template <typename Key, typename... Args>
     std::enable_if_t<has_type<Key, key_list>::value,
                      std::pair<typename std::map<Key, Definition>::iterator, bool>>
-    emplace(Args&&... args)
+    emplace(Key key, Args&&... args)
     {
         return std::get<Index<Key, key_list>::value>(lookup_maps_)
-            .emplace(std::forward<Args>(args)...);
+            .emplace(key.key, std::forward<Args>(args)...);
     }
 
     template <typename Key>
@@ -435,10 +435,10 @@ public:
         return get_holder<Definition>()[key];
     }
 
-    template <typename Definition, typename... Args>
-    auto emplace(Args&&... args)
+    template <typename Definition, typename Key, typename... Args>
+    auto emplace(Key key, Args&&... args)
     {
-        return get_holder<Definition>().emplace(std::forward<Args>(args)...);
+        return get_holder<Definition>().emplace(key, std::forward<Args>(args)...);
     }
 
     template <typename Definition, typename Key>

--- a/include/otf2xx/registry.hpp
+++ b/include/otf2xx/registry.hpp
@@ -222,7 +222,7 @@ public:
 
     template <typename Key, typename... Args>
     std::enable_if_t<has_type<Key, key_list>::value,
-                     std::pair<typename std::map<Key, Definition>::iterator, bool>>
+                     std::pair<typename std::map<Key::key_type, Definition>::iterator, bool>>
     emplace(Key key, Args&&... args)
     {
         return std::get<Index<Key, key_list>::value>(lookup_maps_)


### PR DESCRIPTION
This PR creates a simple registry.emplace() method, which wraps the emplace of the underlying maps