### PR TITLE
Add ability to change regions attributes

### DIFF
--- a/include/otf2xx/definition/detail/region_impl.hpp
+++ b/include/otf2xx/definition/detail/region_impl.hpp
@@ -85,9 +85,19 @@ namespace definition
                 return canonical_name_;
             }
 
+            void canonical_name(const otf2::definition::string& str)
+            {
+                canonical_name_ = str;
+            }
+
             const otf2::definition::string& description() const
             {
                 return description_;
+            }
+
+            void description(const otf2::definition::string& str)
+            {
+                description_ = str;
             }
 
             role_type role() const
@@ -108,6 +118,11 @@ namespace definition
             const otf2::definition::string& source_file() const
             {
                 return source_file_;
+            }
+
+            void source_file(const otf2::definition::string& str)
+            {
+                source_file_ = str;
             }
 
             uint32_t begin_line() const

--- a/include/otf2xx/definition/region.hpp
+++ b/include/otf2xx/definition/region.hpp
@@ -103,6 +103,12 @@ namespace definition
             return data_->canonical_name();
         }
 
+        void canonical_name(const otf2::definition::string& str)
+        {
+            assert(this->is_valid());
+            return data_->canonical_name(str);
+        }
+
         /**
          * \brief returns the description of the region definion as a string definition
          *
@@ -113,6 +119,12 @@ namespace definition
         {
             assert(this->is_valid());
             return data_->description();
+        }
+
+        void description(const otf2::definition::string& str)
+        {
+            assert(this->is_valid());
+            return data_->description(str);
         }
 
         /**
@@ -155,6 +167,12 @@ namespace definition
         {
             assert(this->is_valid());
             return data_->source_file();
+        }
+
+        void source_file(const otf2::definition::string& str)
+        {
+            assert(this->is_valid());
+            return data_->source_file(str);
         }
 
         /**


### PR DESCRIPTION
for:

* source_file
* canonical_name
* description

We set those to the thread name in lo2s, so we need to be able to change them