### PR TITLE
Allow for changing of system tree parent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,7 +37,6 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 
 SpaceBeforeAssignmentOperators: true
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 
 
@@ -50,6 +49,5 @@ SpacesInAngles:  false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpaceAfterControlStatementKeyword: true
-SpaceBeforeAssignmentOperators: true
 ContinuationIndentWidth: 4
 ...

--- a/include/otf2xx/definition/detail/system_tree_node_impl.hpp
+++ b/include/otf2xx/definition/detail/system_tree_node_impl.hpp
@@ -98,6 +98,12 @@ namespace definition
                 return std::make_pair(parent_.get(), pref_);
             }
 
+            void parent(system_tree_node_impl* parent, reference_type pref)
+            {
+                parent_ = otf2::intrusive_ptr<system_tree_node_impl>(parent);
+                pref_ = pref;
+            }
+
         private:
             otf2::definition::string name_;
             otf2::definition::string class_name_;

--- a/include/otf2xx/definition/system_tree_node.hpp
+++ b/include/otf2xx/definition/system_tree_node.hpp
@@ -111,6 +111,11 @@ namespace definition
             return data_->class_name();
         }
 
+        void parent(const otf2::definition::system_tree_node& parent)
+        {
+            data_->parent(parent.get(), parent.ref());
+        }
+
         /**
          * \brief returns the parent
          * \returns otf2::definition::system_tree_node


### PR DESCRIPTION
This PR makes it possible to change the parent of a system_tree_node after it has already been set.

This is useful for lo2s, as I am in the process of rebuilding the Process insertion method.

Currently, we have to take much care to insert the process into the system tree only when we know its parent process, as we can not change it later.

This makes thinking about when in lo2s we already have the system_tree_node  for  a process, and when not,  tedious.

With this change, we can just emplace a bare bones system tree node whenever we need it, as we can simply fill in missing information  (such as the parent) later.