### PR TITLE
Update to OTF2 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,16 +29,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 
 project(otf2xx VERSION 2.0.0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-find_package(OTF2 10.0.0 EXACT)
+find_package(OTF2 3.1 EXACT)
 
 if (NOT OTF2_FOUND)
-    message(FATAL_ERROR "Please download and install OTF2 3.0.\n"
-    "Available from: https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.0/otf2-3.0.tar.gz")
+    message(FATAL_ERROR "Please download and install OTF2 3.1.\n"
+    "Available from: https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.1/otf2-3.1.tar.gz")
 endif()
 
 set(OTF2XX_CHRONO_DURATION_TYPE "picoseconds" CACHE STRING "The used underlying type for otf2::chrono::duration.")

--- a/cmake/FindOTF2.cmake
+++ b/cmake/FindOTF2.cmake
@@ -24,8 +24,8 @@ IF(NOT OTF2_CONFIG OR NOT EXISTS ${OTF2_CONFIG})
 ELSE()
     message(STATUS "OTF2 installation found. (using ${OTF2_CONFIG})")
 
-    execute_process(COMMAND ${OTF2_CONFIG} "--interface-version" OUTPUT_VARIABLE OTF2_VERSION)
-    STRING(REPLACE ":" "." OTF2_VERSION ${OTF2_VERSION})
+    execute_process(COMMAND ${OTF2_CONFIG} "--version" OUTPUT_VARIABLE OTF2_VERSION)
+    STRING(REPLACE "otf2-config: version" "" OTF2_VERSION ${OTF2_VERSION})
     STRING(STRIP ${OTF2_VERSION} OTF2_VERSION)
 
     execute_process(COMMAND ${OTF2_CONFIG} "--cppflags" OUTPUT_VARIABLE OTF2_INCLUDE_DIRS)
@@ -56,9 +56,17 @@ ELSE()
                 SET(_OTF2_NEEDS_PTHREAD TRUE)
                 continue()
             ENDIF()
-            FIND_LIBRARY(_OTF2_LIB_FROM_ARG NAMES ${_ARG}
-                HINTS ${OTF2_LINK_DIRS} NO_DEFAULT_PATH
-            )
+
+            # If --ldflags contains no -L/path/to/otf2, check default
+            # search paths instead (e.g. /usr/lib ...)
+            if(OTF2_LINK_DIRS STREQUAL "")
+                FIND_LIBRARY(_OTF2_LIB_FROM_ARG NAMES ${_ARG})
+            else()
+                FIND_LIBRARY(_OTF2_LIB_FROM_ARG NAMES ${_ARG}
+                    HINTS ${OTF2_LINK_DIRS} NO_DEFAULT_PATH
+                )
+            endif()
+
             IF(${_ARG} STREQUAL "otf2")
                 SET(OTF2_LIBRARY ${_OTF2_LIB_FROM_ARG})
             ELSE()

--- a/include/otf2xx/common.hpp
+++ b/include/otf2xx/common.hpp
@@ -183,7 +183,9 @@ namespace common
         allocate,
         deallocate,
         reallocate,
-        file_io_metadata
+        file_io_metadata,
+        cancel,
+        kernel
     };
 
     enum class paradigm_type
@@ -210,7 +212,10 @@ namespace common
         opencl,
         mtapi,
         sampling,
-        none
+        none,
+        hip,
+        kokkos,
+        openmp_target
     };
 
     enum class paradigm_class_type : std::uint8_t

--- a/tests/enums_test.cpp
+++ b/tests/enums_test.cpp
@@ -149,6 +149,8 @@ using namespace otf2::common;
     static_assert(static_cast<int>(role_type::deallocate) == OTF2_REGION_ROLE_DEALLOCATE, "Enum value mismatch");
     static_assert(static_cast<int>(role_type::reallocate) == OTF2_REGION_ROLE_REALLOCATE, "Enum value mismatch");
     static_assert(static_cast<int>(role_type::file_io_metadata) == OTF2_REGION_ROLE_FILE_IO_METADATA, "Enum value mismatch");
+    static_assert(static_cast<int>(role_type::cancel) == OTF2_REGION_ROLE_CANCEL, "Enum value mismatch");
+    static_assert(static_cast<int>(role_type::kernel) == OTF2_REGION_ROLE_KERNEL, "Enum value mismatch");
 
     static_assert(sizeof(parameter_type) == sizeof(OTF2_ParameterType), "Enum size mismatch");
     static_assert(static_cast<int>(paradigm_type::unknown) == OTF2_PARADIGM_UNKNOWN, "Enum value mismatch");
@@ -174,6 +176,9 @@ using namespace otf2::common;
     static_assert(static_cast<int>(paradigm_type::mtapi) == OTF2_PARADIGM_MTAPI, "Enum value mismatch");
     static_assert(static_cast<int>(paradigm_type::sampling) == OTF2_PARADIGM_SAMPLING, "Enum value mismatch");
     static_assert(static_cast<int>(paradigm_type::none) == OTF2_PARADIGM_NONE, "Enum value mismatch");
+    static_assert(static_cast<int>(paradigm_type::hip) == OTF2_PARADIGM_HIP, "Enum value mismatch");
+    static_assert(static_cast<int>(paradigm_type::kokkos) == OTF2_PARADIGM_KOKKOS, "Enum value mismatch");
+    static_assert(static_cast<int>(paradigm_type::openmp_target) == OTF2_PARADIGM_OPENMP_TARGET, "Enum value mismatch");
 
     static_assert(sizeof(paradigm_class_type) == sizeof(OTF2_ParadigmClass), "Enum size mismatch");
     static_assert(static_cast<int>(paradigm_class_type::process) == OTF2_PARADIGM_CLASS_PROCESS, "Enum value mismatch");


### PR DESCRIPTION
- Update version check to OTF2 3.1
- Replace check against OTF2 interface version with check against OTF2 version.
- Add new role (cancel, kernel) and paradigm types (kokkos, hip, openmp_target).
- Fall back to default find_library search directories if otf2-config --ldflags does not produce a -L/path/to/otf2