### PR TITLE
fix(writer): include chrono/convert.hpp in writer/local.hpp

### DIFF
--- a/include/otf2xx/writer/local.hpp
+++ b/include/otf2xx/writer/local.hpp
@@ -43,6 +43,7 @@
 #include <otf2xx/exception.hpp>
 
 #include <otf2xx/chrono/chrono.hpp>
+#include <otf2xx/chrono/convert.hpp>
 
 namespace otf2
 {


### PR DESCRIPTION
writer/local.hpp uses otf2::chrono::convert, but it is not included directly.